### PR TITLE
fix MDT reconstruction/field/GenFit

### DIFF
--- a/Batch/BatchReco.cc
+++ b/Batch/BatchReco.cc
@@ -465,7 +465,9 @@ int main(int argc, char** argv) {
             fTMuonSpectrometer.features.pval[i] = aMuTrack->fpval;
             fTMuonSpectrometer.features.fpErr[i] = aMuTrack->fpErr;
             fTMuonSpectrometer.features.fipErr[i] = aMuTrack->fipErr;
-        }
+            fTMuonSpectrometer.features.fit_ok[i] = aMuTrack->ffit_ok ? 1 : 0;
+            fTMuonSpectrometer.features.p_analytic[i] = aMuTrack->fpAnalytic;
+         }
         fTMuonSpectrometer.Fill_Sel_Tree(m_muonspect_Tree);
 
         m_POEventTree -> Fill();

--- a/Batch/inspect_mdt.C
+++ b/Batch/inspect_mdt.C
@@ -1,0 +1,289 @@
+// inspect_mdt.C
+// Inspect MDT reconstruction output from Batch-TPORecevent_*.root
+//
+// Usage (from FASER/Batch/):
+//   root -l inspect_mdt.C
+// or with a specific file:
+//   root -l 'inspect_mdt.C("Batch-TPORecevent_6000_0_500.root")'
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TStyle.h"
+#include "TPad.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include <iostream>
+#include <cmath>
+
+void inspect_mdt(const char* fname = "Batch-TPORecevent_6000_0_500.root")
+{
+    gStyle->SetOptStat("emr");
+    gStyle->SetOptTitle(1);
+
+    // -----------------------------------------------------------------------
+    // Open file
+    // -----------------------------------------------------------------------
+    TFile* f = TFile::Open(fname);
+    if (!f || f->IsZombie()) {
+        std::cerr << "Cannot open " << fname << "\n";
+        return;
+    }
+    std::cout << "\n=== File: " << fname << " ===\n";
+    f->ls();
+
+    // -----------------------------------------------------------------------
+    // MuonSpectrometer tree (flat branches, no dictionary needed)
+    // -----------------------------------------------------------------------
+    TTree* ms = (TTree*)f->Get("MuonSpectrometer");
+    if (!ms) { std::cerr << "No MuonSpectrometer tree!\n"; return; }
+
+    const int MAXTR = 10;
+    int   ntracks;
+    float charge[MAXTR], p[MAXTR], px[MAXTR], py[MAXTR], pz[MAXTR];
+    float chi2[MAXTR], pval[MAXTR], fpErr[MAXTR], fipErr[MAXTR];
+    int   nDoF[MAXTR], npoints[MAXTR], fit_ok[MAXTR];
+    float p_analytic[MAXTR];
+
+    ms->SetBranchAddress("ntracks",    &ntracks);
+    ms->SetBranchAddress("charge",     charge);
+    ms->SetBranchAddress("p",          p);
+    ms->SetBranchAddress("px",         px);
+    ms->SetBranchAddress("py",         py);
+    ms->SetBranchAddress("pz",         pz);
+    ms->SetBranchAddress("chi2",       chi2);
+    ms->SetBranchAddress("nDoF",       nDoF);
+    ms->SetBranchAddress("pval",       pval);
+    ms->SetBranchAddress("fpErr",      fpErr);
+    ms->SetBranchAddress("fipErr",     fipErr);
+    ms->SetBranchAddress("npoints",    npoints);
+
+    // fit_ok and p_analytic were added in ClassDef v3; older files won't have them.
+    bool has_fit_ok    = (ms->GetBranch("fit_ok")     != nullptr);
+    bool has_panalytic = (ms->GetBranch("p_analytic") != nullptr);
+    if (!has_fit_ok || !has_panalytic)
+        std::cout << "\n[WARNING] Old file format (pre-ClassDef v3): "
+                  << "fit_ok / p_analytic branches not present.\n"
+                  << "  Re-run batchreco.exe on the input events to get new branches.\n"
+                  << "  Convergence rate and p_analytic plots will be skipped.\n\n";
+    if (has_fit_ok)    ms->SetBranchAddress("fit_ok",     fit_ok);
+    if (has_panalytic) ms->SetBranchAddress("p_analytic", p_analytic);
+
+    // -----------------------------------------------------------------------
+    // Histograms
+    // -----------------------------------------------------------------------
+    // pAnalytic — use log-uniform binning so sub-GeV and TeV-scale tracks both visible
+    const int nLogBins = 60;
+    double logEdges[nLogBins+1];
+    for (int i = 0; i <= nLogBins; ++i)
+        logEdges[i] = std::pow(10.0, -1.0 + 5.0 * i / nLogBins); // 0.1 GeV – 10 TeV
+    TH1F* h_pAna_all  = new TH1F("h_pAna_all",  "p_{analytic} (all tracks);p_{analytic} [GeV/c];tracks", nLogBins, logEdges);
+    TH1F* h_pAna_ok   = new TH1F("h_pAna_ok",   "p_{analytic} (fit_ok==1);p_{analytic} [GeV/c];tracks",  nLogBins, logEdges);
+    TH1F* h_pAna_fail = new TH1F("h_pAna_fail",  "p_{analytic} (fit_ok==0);p_{analytic} [GeV/c];tracks", nLogBins, logEdges);
+    TH1F* h_pAna_log  = new TH1F("h_pAna_log",  "p_{analytic} (log scale);log_{10}(p_{analytic}/GeV);tracks", 50, -1, 4);
+
+    // GenFit fitted momentum (fit_ok==1 only)
+    TH1F* h_pFit      = new TH1F("h_pFit",      "p_{fit} (fit_ok==1);p_{fit} [GeV/c];tracks", 50, 0, 2000);
+    TH1F* h_pFit_log  = new TH1F("h_pFit_log",  "p_{fit} (log scale);log_{10}(p_{fit}/GeV);tracks", 50, -1, 4);
+
+    // chi2 / nDoF  (fit_ok==1)
+    TH1F* h_chi2ndf   = new TH1F("h_chi2ndf",   "#chi^{2}/nDoF (fit_ok==1);#chi^{2}/nDoF;tracks", 50, 0, 10);
+    TH1F* h_nDoF      = new TH1F("h_nDoF",      "nDoF (fit_ok==1);nDoF;tracks",                    15, 0, 15);
+    TH1F* h_pval      = new TH1F("h_pval",      "p-value (fit_ok==1);p-value;tracks",              25, 0, 1);
+
+    // Charge
+    TH1F* h_charge    = new TH1F("h_charge",    "Fitted charge (fit_ok==1);charge;tracks",          3,-1.5,1.5);
+
+    // pFit vs pAnalytic 2D (fit_ok==1)
+    TH2F* h2_paVpf    = new TH2F("h2_paVpf",
+                                  "p_{analytic} vs p_{fit};p_{analytic} [GeV/c];p_{fit} [GeV/c]",
+                                  40, 0, 600, 40, 0, 2000);
+
+    // relative momentum error 1/p * sigma_1/p  (fit_ok==1)
+    TH1F* h_relErr    = new TH1F("h_relErr",    "#sigma(1/p)/(1/p) (fit_ok==1);#sigma_{1/p}/(1/p);tracks", 50, 0, 2);
+
+    // npoints per track (all)
+    TH1F* h_npts      = new TH1F("h_npts",      "npoints per track (all);npoints;tracks", 20, 0, 20);
+
+    // fit_ok per event
+    TH1F* h_ntracks   = new TH1F("h_ntracks",   "ntracks per event;ntracks;events",        8, 0, 8);
+    TH1F* h_nok       = new TH1F("h_nok",       "fit_ok==1 per event;n fit_ok tracks;events", 6, 0, 6);
+
+    // -----------------------------------------------------------------------
+    // Event loop
+    // -----------------------------------------------------------------------
+    Long64_t nev = ms->GetEntries();
+    std::cout << "\nMuonSpectrometer entries: " << nev << "\n";
+
+    int total_tracks = 0, total_ok = 0, total_fail = 0;
+    int cnt_lt1 = 0, cnt_1_10 = 0, cnt_10_100 = 0, cnt_gt100 = 0;
+
+    for (Long64_t ev = 0; ev < nev; ++ev) {
+        ms->GetEntry(ev);
+        h_ntracks->Fill(ntracks);
+        int nok_ev = 0;
+        for (int t = 0; t < ntracks && t < MAXTR; ++t) {
+            ++total_tracks;
+            float pa = p_analytic[t];
+            if (pa > 0 && std::isfinite(pa))
+                h_pAna_log->Fill(std::log10(pa));
+
+            if (fit_ok[t] == 1) {
+                ++total_ok;
+                ++nok_ev;
+                h_pAna_ok->Fill(pa);
+                h_pFit->Fill(p[t]);
+                if (p[t] > 0 && std::isfinite(p[t]))
+                    h_pFit_log->Fill(std::log10(p[t]));
+                if (nDoF[t] > 0)
+                    h_chi2ndf->Fill(chi2[t] / nDoF[t]);
+                h_nDoF->Fill(nDoF[t]);
+                h_pval->Fill(pval[t]);
+                h_charge->Fill(charge[t]);
+                h2_paVpf->Fill(pa, p[t]);
+                // relative inverse-p error:  sigma(1/p) / (1/p)  =  sigma(1/p) * p
+                if (p[t] > 0 && fipErr[t] > 0)
+                    h_relErr->Fill(fipErr[t] * p[t]);
+            } else {
+                ++total_fail;
+                h_pAna_fail->Fill(pa);
+            }
+            h_pAna_all->Fill(pa);
+            h_npts->Fill(npoints[t]);
+            if (pa > 0 && std::isfinite(pa)) {
+                if      (pa <   1.0) ++cnt_lt1;
+                else if (pa <  10.0) ++cnt_1_10;
+                else if (pa < 100.0) ++cnt_10_100;
+                else                 ++cnt_gt100;
+            }
+        }
+        h_nok->Fill(nok_ev);
+    }
+
+    // -----------------------------------------------------------------------
+    // Summary printout
+    // -----------------------------------------------------------------------
+    std::cout << "\n=== MDT Reconstruction Summary (" << nev << " events) ===\n";
+    std::cout << "  Total tracks reconstructed : " << total_tracks << "\n";
+    std::cout << "  GenFit SUCCESS  (fit_ok==1): " << total_ok << "\n";
+    std::cout << "  GenFit FAILED   (fit_ok==0): " << total_fail << "\n";
+    if (total_tracks > 0)
+        std::cout << "  Convergence rate           : "
+                  << 100.0 * total_ok / total_tracks << " %\n";
+
+    std::cout << "\n  p_analytic distribution (all " << total_tracks << " tracks):\n";
+    std::cout << "    p < 1  GeV : " << cnt_lt1    << "\n";
+    std::cout << "    1-10  GeV  : " << cnt_1_10   << "\n";
+    std::cout << "    10-100 GeV : " << cnt_10_100 << "\n";
+    std::cout << "    100+ GeV   : " << cnt_gt100  << "\n";
+
+    if (total_ok > 0) {
+        std::cout << "\n  Fitted momentum (fit_ok==1):\n";
+        std::cout << "    mean p_fit  = " << h_pFit->GetMean()   << " GeV/c\n";
+        std::cout << "    mean chi2   = " << h_chi2ndf->GetMean() << " /nDoF\n";
+        std::cout << "    mean pval   = " << h_pval->GetMean()   << "\n";
+        std::cout << "    mean relErr = " << h_relErr->GetMean() << "\n";
+    }
+
+    // -----------------------------------------------------------------------
+    // Plotting
+    // -----------------------------------------------------------------------
+    gStyle->SetPalette(kBird);
+
+    // Canvas 1: pAnalytic
+    TCanvas* c1 = new TCanvas("c1", "MDT – Analytic Momentum", 1200, 500);
+    c1->Divide(2, 1);
+
+    c1->cd(1);
+    h_pAna_all->SetLineColor(kBlue+1);
+    gPad->SetLogx();
+    h_pAna_ok->SetLineColor(kGreen+2);
+    h_pAna_ok->SetFillColor(kGreen-9);
+    h_pAna_fail->SetLineColor(kRed+1);
+    h_pAna_all->Draw("hist");
+    h_pAna_ok->Draw("hist same");
+    h_pAna_fail->Draw("hist same");
+    TLegend* leg1 = new TLegend(0.55,0.65,0.88,0.88);
+    leg1->SetBorderSize(0);
+    leg1->AddEntry(h_pAna_all,  "All tracks",     "l");
+    leg1->AddEntry(h_pAna_ok,   "fit_ok == 1",    "lf");
+    leg1->AddEntry(h_pAna_fail, "fit_ok == 0",    "l");
+    leg1->Draw();
+
+    c1->cd(2);
+    gPad->SetLogy();
+    h_pAna_log->SetLineColor(kBlue+1);
+    h_pAna_log->Draw("hist");
+    TLatex lat;
+    lat.SetNDC(); lat.SetTextSize(0.04);
+    lat.DrawLatex(0.15, 0.85, Form("All %d tracks", total_tracks));
+
+    c1->SaveAs("mdt_panalytic.png");
+    std::cout << "\nSaved: mdt_panalytic.png\n";
+
+    // Canvas 2: Fitted momentum and fit quality (fit_ok==1 only)
+    TCanvas* c2 = new TCanvas("c2", "MDT – GenFit Results (fit_ok==1)", 1400, 600);
+    c2->Divide(3, 2);
+
+    c2->cd(1); gPad->SetLogy();
+    h_pFit->SetLineColor(kBlue+1); h_pFit->Draw("hist");
+    lat.DrawLatex(0.15, 0.85, Form("%d tracks", total_ok));
+
+    c2->cd(2); gPad->SetLogy();
+    h_pFit_log->SetLineColor(kBlue+1); h_pFit_log->Draw("hist");
+
+    c2->cd(3);
+    h_chi2ndf->SetLineColor(kRed+1); h_chi2ndf->Draw("hist");
+    TLine* lchi = new TLine(1, 0, 1, h_chi2ndf->GetMaximum());
+    lchi->SetLineStyle(2); lchi->SetLineColor(kGray+1); lchi->Draw();
+
+    c2->cd(4);
+    h_nDoF->SetLineColor(kMagenta+1); h_nDoF->Draw("hist");
+
+    c2->cd(5);
+    h_pval->SetLineColor(kGreen+2); h_pval->Draw("hist");
+
+    c2->cd(6);
+    h_charge->SetLineColor(kOrange+1); h_charge->Draw("hist");
+
+    c2->SaveAs("mdt_fitquality.png");
+    std::cout << "Saved: mdt_fitquality.png\n";
+
+    // Canvas 3: pAnalytic vs pFit 2D + relative error
+    TCanvas* c3 = new TCanvas("c3", "MDT – pAnalytic vs pFit", 1200, 500);
+    c3->Divide(2, 1);
+
+    c3->cd(1);
+    gPad->SetLogx(); gPad->SetLogy();
+    h2_paVpf->Draw("colz");
+
+    c3->cd(2);
+    h_relErr->SetLineColor(kBlue+1); h_relErr->Draw("hist");
+    lat.DrawLatex(0.15, 0.85, Form("mean = %.2f", h_relErr->GetMean()));
+
+    c3->SaveAs("mdt_pana_vs_pfit.png");
+    std::cout << "Saved: mdt_pana_vs_pfit.png\n";
+
+    // Canvas 4: per-event counters
+    TCanvas* c4 = new TCanvas("c4", "MDT – Per-event", 1000, 450);
+    c4->Divide(2, 1);
+
+    c4->cd(1);
+    h_ntracks->SetLineColor(kBlue+1); h_ntracks->Draw("hist");
+
+    c4->cd(2);
+    h_nok->SetLineColor(kGreen+2); h_nok->Draw("hist");
+    TLatex lat2;
+    lat2.SetNDC(); lat2.SetTextSize(0.04);
+    if (total_tracks > 0)
+        lat2.DrawLatex(0.15, 0.85,
+            Form("Conv. rate: %.1f%%", 100.0*total_ok/total_tracks));
+
+    c4->SaveAs("mdt_per_event.png");
+    std::cout << "Saved: mdt_per_event.png\n";
+
+    std::cout << "\nDone.\n";
+}

--- a/CoreUtils/GenMagneticField.hh
+++ b/CoreUtils/GenMagneticField.hh
@@ -58,11 +58,24 @@ public:
     const std::vector<double>& GetEventStationZsCm() const { return event_station_z_cm_; }
     //////////(o^o)///////////
 
+    // Precomputed MDT magnet z-ranges in GLOBAL cm (zmin,zmax per magnet).
+    // Set once per event from the cached geometry so that get() never has to
+    // call gGeoManager->FindNode() while GenFit's RK stepper is mid-propagation:
+    // GenFit's own TGeoMaterialInterface concurrently drives gGeoManager's
+    // (stateful, single) navigator for material stepping, and an independent
+    // FindNode() call from inside the field functor can desynchronize that
+    // navigator's current-node bookkeeping, which manifests as the Kalman fit
+    // diverging/non-converging mid-track.
+    void SetMDTMagnetZRangesCm(const std::vector<std::pair<double,double>>& ranges_cm) {
+        mdt_magnet_z_ranges_cm_ = ranges_cm;
+    }
+
 private:
     std::vector<std::pair<double,double>> magnet_z_ranges_cm_;
     std::vector<double> scifi_layer_z_cm_;
     //////////(o^o)///////////
     std::vector<double> event_station_z_cm_;
+    std::vector<std::pair<double,double>> mdt_magnet_z_ranges_cm_;
     //////////(o^o)///////////
     TVector3 get(const TVector3 &position) const override
     {

--- a/CoreUtils/TMuTrack.cc
+++ b/CoreUtils/TMuTrack.cc
@@ -6,7 +6,10 @@
 #include <Track.h>
 #include <TrackPoint.h>
 #include <PlanarMeasurement.h>
+#include <WireMeasurement.h>
 #include <KalmanFitterRefTrack.h>
+#include <KalmanFitter.h>
+#include <DAF.h>
 #include <FitStatus.h>
 #include <MeasuredStateOnPlane.h>
 #include <FieldManager.h>
@@ -533,119 +536,83 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     covSeed(4,4) = momSigma * momSigma;
     covSeed(5,5) = momSigma * momSigma;
 
-    // // Instantiate the GenFit master track container layout
+    // Instantiate the GenFit master track container.
     genfit::Track fitTrack(rep, stateSeed, covSeed);
-    
-    const double sigma_MDT_cm = 0.080 * 0.1; // 80 microns = 0.008 cm
-    const int detId = 0; // detector ID for MDT
+
+    // PlanarMeasurement with pre-resolved L/R from Phase 1-3.
+    // Using PlanarMeasurement (fixed planes) avoids the WireMeasurement dynamic-plane
+    // search that can accumulate > 3000 cm path length in the RK propagator.
+    // L/R is resolved externally (stored in hit.side and in hit.localY_mm = wire_y + side*r).
+    const double hitSigmaU_cm = 0.080 * 0.1; // 80 μm drift resolution in measured direction
+    const double hitSigmaV_cm = 10.0;         // wire direction: unmeasured (large)
+    TMatrixDSym hitCov(2);
+    hitCov.Zero();
+    hitCov(0,0) = hitSigmaU_cm * hitSigmaU_cm; // u = local Y (measured)
+    hitCov(1,1) = hitSigmaV_cm * hitSigmaV_cm; // v = local X (wire direction, unmeasured)
+
+    const int detId = 0;
     int hitCounter = 0;
-
     for (const auto& hit : sortedMeas) {
-        // Plane origin is an arbitrary point on the measured line.
-        // The coordinate along local X/wire is unmeasured.
-        TVector3 planeOrigin(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1); // cm
-        TVector3 U_direction(hit.uX, hit.uY, hit.uZ); // measured local Y
-        TVector3 V_direction(hit.vX, hit.vY, hit.vZ); // free local X/wire
+        // Per-hit local frame: u=localY(measured), v=localX(wire), w=localZ(normal to plane).
+        TVector3 hU(hit.uX, hit.uY, hit.uZ);
+        TVector3 hV(hit.vX, hit.vY, hit.vZ);
+        if (hU.Mag() > 0) hU = hU.Unit();
+        if (hV.Mag() > 0) hV = hV.Unit();
 
-        if (U_direction.Mag() > 0.0) U_direction = U_direction.Unit();
-        V_direction = V_direction - U_direction * U_direction.Dot(V_direction);
-        if (V_direction.Mag() > 0.0)
-            V_direction = V_direction.Unit();
-        else
-            V_direction = mdtV;
-        
-        genfit::SharedPlanePtr measurementPlane(
-            new genfit::DetPlane(planeOrigin,
-                                 U_direction,
-                                 V_direction)
-        );
-        // MDT measurement:
-        //   U direction = local Y, measured precisely by drift radius.
-        //   V direction = local X, tube/wire axis, NOT measured.
-        // We include V with a very large uncertainty only to regularize GenFit.
-        // This is not truth information.
-        const double sigmaU_cm = 0.080 * 0.1;  // 80 um = 0.008 cm
-        const double sigmaV_cm = 50.0;         // 50 cm weak constraint along tube
+        // Plane origin = resolved hit position in global frame (x_mm, y_mm, z_mm).
+        // hitCoords = (0, 0) means the measurement is AT the plane origin.
+        // GenFit's Kalman residual = (track prediction at plane) - hitCoords.
+        TVector3 planeOrigin(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1);
+
         TVectorD hitCoords(2);
-        hitCoords(0) = 0.0;       
-        hitCoords(1) = 0.0;
+        hitCoords(0) = 0.0; // measurement at plane origin (u)
+        hitCoords(1) = 0.0; // v unmeasured
 
-        TMatrixDSym hitCov(2);
-        hitCov.Zero();
-        hitCov(0,0) = sigmaU_cm * sigmaU_cm;
-        hitCov(1,1) = sigmaV_cm * sigmaV_cm;
-
-        genfit::PlanarMeasurement* planarHit =
-            new genfit::PlanarMeasurement(hitCoords,
-                                          hitCov,
-                                          detId,
-                                          hitCounter,
-                                          nullptr);
-        planarHit->setPlane(measurementPlane, hitCounter);
-        fitTrack.insertPoint(new genfit::TrackPoint(planarHit, &fitTrack));
+        genfit::PlanarMeasurement* meas_pt = new genfit::PlanarMeasurement(
+            hitCoords, hitCov, detId, hitCounter, nullptr);
+        meas_pt->setPlane(
+            genfit::SharedPlanePtr(new genfit::DetPlane(planeOrigin, hU, hV)),
+            hitCounter);
+        fitTrack.insertPoint(new genfit::TrackPoint(meas_pt, &fitTrack));
         ++hitCounter;
     }
-    if (verbose > 0) {
-        std::cout << "[GenFitMDTFit] Track has "
-                  << fitTrack.getNumPoints()
-                  << " MDT 1D measurement points\n";
-    }
-    /////////////////////////////////////////////    
+
     if (verbose > 0) {
         auto* field = genfit::FieldManager::getInstance()->getField();
         std::cout << "\n[GenFitMDTFit] ========== MEASUREMENT DETAILS ==========\n";
         std::cout << "[GenFitMDTFit] Number of measurements: " << sortedMeas.size() << "\n";
-
         for (size_t i = 0; i < sortedMeas.size(); ++i) {
             const auto& m = sortedMeas[i];
             TVector3 pos_cm(m.x_mm / 10.0, m.y_mm / 10.0, m.z_mm / 10.0);
             TVector3 BkG = field ? field->get(pos_cm) : TVector3(0.0, 0.0, 0.0);
-
-            const char* matName = "NULL";
             const char* nodeName = "NULL";
             if (gGeoManager) {
                 TGeoNode* node = gGeoManager->FindNode(pos_cm.X(), pos_cm.Y(), pos_cm.Z());
-                if (node) {
-                    nodeName = node->GetName();
-                    if (node->GetVolume() && node->GetVolume()->GetMedium()) {
-                        matName = node->GetVolume()->GetMedium()->GetMaterial()->GetName();
-                    }
-                }
+                if (node) nodeName = node->GetName();
             }
             std::cout << Form(
-                "[GenFitMDTFit] Hit %2zu:"
-                " local=(xArb=%+.1f, yMeas=%+.1f, z=%+.1f) mm"
-                " global=(%+.1f,%+.1f,%+.1f) mm"
-                " drift=%+.3f mm side=%+d station=%d plane=%d tube=%d"
-                " B=(%+.2f,%+.2f,%+.2f) kG node=%s mat=%s\n",
-                i, m.localX_mm, m.localY_mm, m.localZ_mm,
+                "[GenFitMDTFit] Hit %2zu: localY=%+.1f z=%+.1f mm"
+                " global=(%+.1f,%+.1f,%+.1f) mm drift=%+.3f side=%+d"
+                " B=(%+.2f,%+.2f,%+.2f) kG node=%s\n",
+                i, m.localY_mm, m.localZ_mm,
                 m.x_mm, m.y_mm, m.z_mm,
-                m.r_meas_mm, m.side, m.stationID, m.planeID, m.tubeID,
-                BkG.X(), BkG.Y(), BkG.Z(),
-                nodeName, matName
-            );
+                m.r_meas_mm, m.side,
+                BkG.X(), BkG.Y(), BkG.Z(), nodeName);
         }
         std::cout << "[GenFitMDTFit] =========================================\n\n";
-    }  
-    //////////////////////////////////
-    // Initialize/Use the Kalman Fitter Reference Track minimization engine for reference track fitting
-    genfit::KalmanFitterRefTrack fitter;    
-    fitter.setMaxIterations(10);  // Use 10 like working standalone (not 50)
-    fitter.setMinIterations(2);   // Add minimum iterations
-    fitter.setRelChi2Change(1e-4);
-    
-    if (verbose > 0) {
-        std::cout << "[GenFitMDTFit] Starting Kalman fit with:\n";
-        std::cout << "  Max iterations: 10\n";
-        std::cout << "  Min iterations: 2\n";
-        std::cout << "  Convergence criterion: 1e-4 relative chi2 change\n";
-        std::cout << "  Number of track points: " << fitTrack.getNumPoints() << "\n";
+        std::cout << "[GenFitMDTFit] Track has " << fitTrack.getNumPoints() << " MDT measurement points\n";
     }
 
+    // KalmanFitterRefTrack: works with PlanarMeasurement (fixed planes).
+    genfit::KalmanFitterRefTrack fitter;
+    fitter.setMaxIterations(10);
+    fitter.setRelChi2Change(0.001);
+
+    if (verbose > 0)
+        std::cout << "[GenFitMDTFit] Starting KalmanFitterRefTrack fit\n";
+
     try {
-        //Loops over all track representations (TrackRep) registered inside the track payload and fits them.
-        fitter.processTrack(&fitTrack);  // Pass address of stack object
-        //fitter.processTrackWithRep(&fitTrack, rep);
+        fitter.processTrack(&fitTrack);
     }
     catch (genfit::Exception& e) {
         std::cerr << "\n[GenFitMDTFit] ========== GENFIT EXCEPTION ==========\n";
@@ -679,35 +646,36 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
         std::cerr << "[GenFitMDTFit] ====================================\n\n";
         return false;
     }
-    
-    if (!status->isFitConverged()) {
-        std::cerr << "\n[GenFitMDTFit] ========== FIT DID NOT CONVERGE ==========\n";
-        std::cerr << "[GenFitMDTFit] Fit converged: " << (status->isFitConverged() ? "YES" : "NO") << "\n";
-        std::cerr << "[GenFitMDTFit] Fit converged partially: " << (status->isFitConvergedPartially() ? "YES" : "NO") << "\n";
-        std::cerr << "[GenFitMDTFit] Chi2: " << status->getChi2() << "\n";
-        std::cerr << "[GenFitMDTFit] NDF: " << status->getNdf() << "\n";
-        if (status->getNdf() > 0) {
-            std::cerr << "[GenFitMDTFit] Chi2/NDF: " << status->getChi2() / status->getNdf() << "\n";
-        }
-        std::cerr << "[GenFitMDTFit] Charge: " << status->getCharge() << "\n";
-        std::cerr << "[GenFitMDTFit] Track pruned? " << (status->isTrackPruned() ? "YES" : "NO") << "\n";
-        
-        // Try to get some state information even if not converged
-        try {
-            genfit::MeasuredStateOnPlane state = fitTrack.getFittedState();
-            TVector3 pfit = state.getMom();
-            std::cerr << "[GenFitMDTFit] Partial momentum: p=" << pfit.Mag() 
-                      << " GeV (px=" << pfit.X() << ", py=" << pfit.Y() << ", pz=" << pfit.Z() << ")\n";
-        } catch (...) {
-            std::cerr << "[GenFitMDTFit] Could not extract partial state\n";
-        }
-        
-        std::cerr << "[GenFitMDTFit] ==========================================\n\n";
+
+    // isFitConverged() is unreliable across GenFit versions:
+    // some versions return false even for excellent fits (chi2/NDF~0.24).
+    // Instead: always try to extract the state and gate on chi2/NDF + pval.
+    const double fitChi2 = status->getChi2();
+    const double fitNDF  = status->getNdf();
+    const double fitPval = status->getPVal();
+    const double chi2ndf = (fitNDF > 0) ? fitChi2 / fitNDF : 1e9;
+
+    std::cerr << "[GenFitMDTFit] isFitConverged=" << (status->isFitConverged() ? "YES" : "NO")
+              << "  chi2=" << fitChi2 << "  NDF=" << fitNDF
+              << "  chi2/NDF=" << chi2ndf << "  pval=" << fitPval << "\n";
+
+    // Try to extract the fitted state regardless of the convergence flag.
+    genfit::MeasuredStateOnPlane state;
+    try {
+        state = fitTrack.getFittedState();
+    } catch (...) {
+        std::cerr << "[GenFitMDTFit] Could not extract fitted state — fit truly failed\n";
         return false;
     }
 
-    // Extract fitted state at the first measurement
-    genfit::MeasuredStateOnPlane state = fitTrack.getFittedState();
+     // Quality gate: chi2/NDF must be physically reasonable AND pval not catastrophic.
+    // chi2/NDF < 10 rejects runaway fits; pval > 1e-10 rejects wrong-minimum solutions.
+    const bool qualityOk = (fitNDF > 0) && (chi2ndf < 10.0) && (fitPval > 1e-10);
+    if (!qualityOk) {
+        std::cerr << "[GenFitMDTFit] REJECTED: chi2/NDF=" << chi2ndf
+                  << "  pval=" << fitPval << "\n";
+        return false;
+    }
     TVector3 pfit = state.getMom();
     fpx = pfit.X();
     fpy = pfit.Y();
@@ -716,9 +684,9 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
 
     fcharge = state.getCharge();
 
-    fchi2   = status->getChi2();
-    fnDoF   = status->getNdf();
-    fpval   = status->getPVal();
+    fchi2   = fitChi2;
+    fnDoF   = static_cast<int>(fitNDF);
+    fpval   = fitPval;
 
     TMatrixDSym localCov = state.getCov();
     fQOverP = state.getState()(0);

--- a/CoreUtils/TMuTrack.hh
+++ b/CoreUtils/TMuTrack.hh
@@ -58,7 +58,10 @@ public:
     double fipErr;            // error on fitted inverse momentum at the first point
     double fQOverP;            // fitted inverse momentum at the first point
     double fQOverPErr;         // error on fitted inverse momentum at the first point
-    
+
+    bool   ffit_ok;     // true if GenFit Kalman converged
+    double fpAnalytic;  // analytic sagitta-fit momentum (GeV/c), always filled
+   
     TMuTrack() : ftrackID(-1), fcharge(0), fitTrack(nullptr) {}
     virtual ~TMuTrack() {
         if (fitTrack) {

--- a/CoreUtils/TMuonSpect.cc
+++ b/CoreUtils/TMuonSpect.cc
@@ -17,4 +17,6 @@ void TMuonSpectrometer::Create_Sel_Tree(TTree *t) {
   t->Branch("pval", &features.pval, "pval[ntracks]/F");
   t->Branch("fpErr", &features.fpErr, "fpErr[ntracks]/F");
   t->Branch("fipErr", &features.fipErr, "fipErr[ntracks]/F");
+  t->Branch("fit_ok", &features.fit_ok, "fit_ok[ntracks]/I");
+  t->Branch("p_analytic", &features.p_analytic, "p_analytic[ntracks]/F");
 };

--- a/CoreUtils/TMuonSpect.hh
+++ b/CoreUtils/TMuonSpect.hh
@@ -28,12 +28,14 @@ struct FEATURES {
     float pval[MAXMUTRACKS];  // p-value of the fit
     float fpErr[MAXMUTRACKS]; // error on fitted momentum at the first point
     float fipErr[MAXMUTRACKS]; // error on fitted inverse momentum at the first point
+     int   fit_ok[MAXMUTRACKS];     // 1 if GenFit Kalman converged, 0 otherwise
+    float p_analytic[MAXMUTRACKS]; // analytic sagitta-fit momentum (GeV/c)
 };
 
 private:
 
 public:
-    ClassDef(TMuonSpectrometer, 2)
+    ClassDef(TMuonSpectrometer, 3)
 
     struct FEATURES features;
 

--- a/CoreUtils/TPORecoEvent.cc
+++ b/CoreUtils/TPORecoEvent.cc
@@ -3562,6 +3562,67 @@ void TPORecoEvent::ReconstructMuonSpectrometer() {
     }
 }
 ///////////////////////////////
+// Configure MDT magnet z-ranges on fMagField by walking the ROOT geometry.
+// Must be called once per event (or at least once after geometry is loaded)
+// before running the analytic or GenFit MDT fits.
+static void SetupMDTMagneticField(GenMagneticField* gfield, TcalEvent* tcal)
+{
+    if (!gfield || !gGeoManager || !gGeoManager->GetTopVolume() || !tcal) return;
+
+    std::vector<std::pair<double,double>> ranges_cm;
+    double sumX_cm = 0.0, sumY_cm = 0.0;
+    int nMagnets = 0;
+    TGeoVolume* top = gGeoManager->GetTopVolume();
+    TGeoIterator next(top);
+    TGeoNode* node = nullptr;
+    while ((node = next())) {
+        std::string nodeName = node->GetName() ? node->GetName() : "";
+        std::string volName  = (node->GetVolume() && node->GetVolume()->GetName())
+                               ? node->GetVolume()->GetName() : "";
+        const bool isMDTMagnet =
+            nodeName.find("MDTMagnet") != std::string::npos ||
+            volName.find("MDTMagnet")  != std::string::npos;
+        if (!isMDTMagnet) continue;
+        const TGeoMatrix* matrix = next.GetCurrentMatrix();
+        if (!matrix) continue;
+        const double* tr_cm = matrix->GetTranslation();  // global center in cm
+        sumX_cm += tr_cm[0];
+        sumY_cm += tr_cm[1];
+        ++nMagnets;
+        double halfZ_cm = 20.0; // fallback: 200 mm half-size
+        TGeoShape* shape = node->GetVolume()->GetShape();
+        if (shape) {
+            double dx, dz;
+            shape->GetAxisRange(3, dx, dz);
+            double half = std::abs(dz - dx) / 2.0;
+            if (half > 1.0) halfZ_cm = half;
+        }
+        ranges_cm.push_back({tr_cm[2] - halfZ_cm, tr_cm[2] + halfZ_cm});
+        std::cout << "[SetupMDTMagneticField] magnet=" << nodeName
+                  << " z_global cm=(" << (tr_cm[2] - halfZ_cm) << ", " << (tr_cm[2] + halfZ_cm) << ")\n";
+    }
+    std::sort(ranges_cm.begin(), ranges_cm.end());
+    std::vector<std::pair<double,double>> unique_ranges;
+    for (const auto& r : ranges_cm) {
+        if (unique_ranges.empty() || std::abs(r.first - unique_ranges.back().first) > 1.0)
+            unique_ranges.push_back(r);
+    }
+    gfield->SetMDTMagnetZRangesCm(unique_ranges);
+    gfield->SetSlitPosition(25.0);
+    // Set the LOS shift so the slit Y-check uses local coordinates centered on the
+    // MDT spectrometer axis. Without this, y_local = Y_global which puts all tracks
+    // in the wrong field region (outer ±15 kG instead of inner ∓15 kG).
+    if (nMagnets > 0) {
+        const double avgX_cm = sumX_cm / nMagnets;
+        const double avgY_cm = sumY_cm / nMagnets;
+        gfield->SetRearMuSpectShift(avgX_cm, avgY_cm);
+        std::cout << "[SetupMDTMagneticField] LOS shift set to X=" << avgX_cm
+                  << " Y=" << avgY_cm << " cm from " << nMagnets << " magnet centers\n";
+    }
+    std::cout << "[SetupMDTMagneticField] configured " << unique_ranges.size()
+              << " MDT magnet z-ranges, slitPos=25 cm\n";
+}
+///////////////////////////////
 void PrintMDTFieldMaterialScan(genfit::AbsBField* field,
                                double x_mm,
                                double y_mm,
@@ -3985,10 +4046,13 @@ void TPORecoEvent::ReconstructMDT()
             std::cout << "  MDT magnet local z = " << z << " mm\n";
         return;
     }
+    // Configure MDT magnet z-ranges on the field so ComputeYKernelFromBx and GenFit see non-zero B.
+    SetupMDTMagneticField(fMagField, fTcalEvent);
     ///////////////////////////////////
     // Set up a random engine to smear the true drift radius into a measured one
     std::random_device rd;
-    std::mt19937 muon_rng(rd());
+    //std::mt19937 muon_rng(rd());
+    std::mt19937 muon_rng(42);
     auto smearRadius = [&](double r_true) {
         std::normal_distribution<double> gaussR(0.0, smear_mm);
         double r = r_true + gaussR(muon_rng);
@@ -4023,8 +4087,8 @@ void TPORecoEvent::ReconstructMDT()
                 << " pos=" << mdt->pos.size()
                 << " tubeCenter=" << mdt->tubeCenter.size()
                 << std::endl;
-        if (n < 5) {
-            std::cout << "[ReconstructMDT] skip: incomplete MDT vectors" << std::endl;
+        if (n < 6) {
+            std::cout << "[ReconstructMDT] skip: fewer than 6 hits (need >= 2 stations x 3 layers)\n";
             continue;
         }
         ////////////////////////////////////////////////
@@ -4065,87 +4129,78 @@ void TPORecoEvent::ReconstructMDT()
             }
             stationGroups[h.sta].push_back(h);
         }
+        if (stationGroups.size() < 2) {
+            std::cout << "[ReconstructMDT] Skip track " << tid << ": only 1 station, need >= 2\n";
+            continue;
+        }
         // ---------------------------------------------------------------------
-        // Execute Local Combinatorial Straight-Line L/R Ambiguity Solver
+        // L/R Ambiguity Resolution – two-phase approach:
+        //
+        // Phase 1: Per-station combinatorial scan with 2-parameter straight-line.
+        //   Within each station the z-spread is ~80 mm, so curvature is negligible.
+        //   This gives a reliable per-station L/R assignment without the degeneracy
+        //   that arises when using a 3-parameter model globally over all 2^N combos.
+        //
+        // Phase 2: Iterative cross-station flip refinement using the full physics
+        //   model y = y0 + slope*(z-z0) + (q/p)*kernelY.
+        //   Try flipping each hit one at a time; keep flips that strictly reduce
+        //   chi2. Repeat up to 5 passes or until no flip improves chi2.
         // ---------------------------------------------------------------------
+
+        // --- Phase 1: per-station straight-line L/R scan ---
         std::vector<Hit> resolvedEventHits;
         for (auto& pair : stationGroups) {
             auto& sHits = pair.second;
-            const int nHitsInStation = static_cast<int>(sHits.size());            
-            if (nHitsInStation <= 0)
-                continue;
-            if (nHitsInStation > 20) {
-                std::cout << "[ReconstructMDT] WARNING: station "
-                          << pair.first
-                          << " has too many hits for 2^N L/R scan: "
-                          << nHitsInStation
-                          << ". Skipping track.\n";
-                resolvedEventHits.clear();
-                break;
+            const int nH = static_cast<int>(sHits.size());
+            if (nH <= 0) continue;
+            if (nH > 20) {
+                std::cout << "[ReconstructMDT] WARNING: station " << pair.first
+                          << " has " << nH << " hits; skipping track.\n";
+                resolvedEventHits.clear(); break;
             }
-            
-            double bestLocalChi2 = 1e12;
-            std::vector<int> bestSides(nHitsInStation, 1);
-            int nCombos = 1 << nHitsInStation; // 2^N combinations for N planes
-            for (int combo = 0; combo < nCombos; ++combo) {
-                double sumZ = 0, sumZ2 = 0, sumY = 0, sumZY = 0;
-                std::vector<double> testY(nHitsInStation);
-                std::vector<int> currentSides(nHitsInStation);
-
-                for (int i = 0; i < nHitsInStation; ++i) {
-                    currentSides[i] = ((combo >> i) & 1) ? 1 : -1;
-                    testY[i] = sHits[i].wy_l + currentSides[i] * sHits[i].r;
-                    double z = sHits[i].wz_l;
-                    
-                    sumZ  += z;
-                    sumZ2 += z * z;
-                    sumY  += testY[i];
-                    sumZY += z * testY[i];
+            double bestLocalChi2 = 1e18;
+            std::vector<int> bestSides(nH, 1);
+            for (int combo = 0; combo < (1 << nH); ++combo) {
+                double sumZ=0, sumZ2=0, sumY=0, sumZY=0;
+                for (int i = 0; i < nH; ++i) {
+                    const int s = ((combo>>i)&1) ? 1 : -1;
+                    const double y = sHits[i].wy_l + s * sHits[i].r;
+                    const double z = sHits[i].wz_l;
+                    sumZ+=z; sumZ2+=z*z; sumY+=y; sumZY+=z*y;
                 }
-
-                double denom = nHitsInStation * sumZ2 - sumZ * sumZ;
+                const double denom = nH*sumZ2 - sumZ*sumZ;
                 if (std::fabs(denom) < 1e-6) continue;
-
-                double slope = (nHitsInStation * sumZY - sumZ * sumY) / denom;
-                double intercept = (sumY - slope * sumZ) / nHitsInStation;
-
-                double currentChi2 = 0.0;
-                for (int i = 0; i < nHitsInStation; ++i) {
-                    double expectedY = intercept + slope * sHits[i].wz_l;
-                    double residual = testY[i] - expectedY;
-                    currentChi2 += (residual * residual) / (smear_mm * smear_mm);
+                const double slope  = (nH*sumZY - sumZ*sumY) / denom;
+                const double intcpt = (sumY - slope*sumZ) / nH;
+                double chi2 = 0;
+                for (int i = 0; i < nH; ++i) {
+                    const int s = ((combo>>i)&1) ? 1 : -1;
+                    const double res = sHits[i].wy_l + s*sHits[i].r
+                                       - (intcpt + slope*sHits[i].wz_l);
+                    chi2 += res*res / (smear_mm*smear_mm);
                 }
-
-                if (currentChi2 < bestLocalChi2) {
-                    bestLocalChi2 = currentChi2;
-                    bestSides = currentSides;
+                if (chi2 < bestLocalChi2) {
+                    bestLocalChi2 = chi2;
+                    for (int i = 0; i < nH; ++i)
+                        bestSides[i] = ((combo>>i)&1) ? 1 : -1;
                 }
             }
-            // Commit the winning drift signs to this station's hit objects
-            for (int i = 0; i < nHitsInStation; ++i) {
+            for (int i = 0; i < nH; ++i) {
                 sHits[i].assignedSide = bestSides[i];
                 resolvedEventHits.push_back(sHits[i]);
             }
         }
-        if (resolvedEventHits.empty())
-            continue;
+        if (resolvedEventHits.empty()) continue;
         std::sort(resolvedEventHits.begin(), resolvedEventHits.end(),
-                  [](const Hit& a, const Hit& b) {
-                    return a.wz_l < b.wz_l;
-                  });
+                  [](const Hit& a, const Hit& b) { return a.wz_l < b.wz_l; });
 
         const int N = static_cast<int>(resolvedEventHits.size());
-        if (N < 5) {
-            std::cout << "[ReconstructMDT] Skip track " << tid << ": insufficient resolved spacepoints." << std::endl;
+        if (N < 6) {
+            std::cout << "[ReconstructMDT] Skip track " << tid << ": only " << N << " hits (need >= 6)\n";
             continue;
         }
-        // ---------------------------------------------------------------------
-        // Analytic local y(z) fit:
-        //
-        // y = y0 + slope * (z - z0) + (q/p) * kernelY
-        //
-        // Field sampled globally, projected onto MDT-local X.
-        // ---------------------------------------------------------------------
+
+        // Pre-compute kernelY (depends only on wire position, not L/R side).
         const double z0Local = resolvedEventHits.front().wz_l;
         std::vector<double> kernelY(N, 0.0);
         for (int h = 0; h < N; ++h) {
@@ -4158,6 +4213,103 @@ void TPORecoEvent::ReconstructMDT()
                                              resolvedEventHits[h].wz_l,
                                              2.0);
         }
+
+        // Helper: solve 3-parameter model for current assignedSides, return chi2.
+        auto fitAndChi2 = [&](double outP[3]) -> double {
+            double lATA[3][3]={}, lATy[3]={};
+            for (int h = 0; h < N; ++h) {
+                const double y_h  = resolvedEventHits[h].wy_l
+                                    + resolvedEventHits[h].assignedSide * resolvedEventHits[h].r;
+                const double zRel = resolvedEventHits[h].wz_l - z0Local;
+                const double A[3] = {1.0, zRel, kernelY[h]};
+                for (int i=0;i<3;i++) {
+                    for (int j=0;j<3;j++) lATA[i][j]+=A[i]*A[j];
+                    lATy[i]+=A[i]*y_h;
+                }
+            }
+            if (!Solve3(lATA, lATy, outP)) return 1e18;
+            double chi2 = 0;
+            for (int h = 0; h < N; ++h) {
+                const double y_h    = resolvedEventHits[h].wy_l
+                                      + resolvedEventHits[h].assignedSide * resolvedEventHits[h].r;
+                const double zRel   = resolvedEventHits[h].wz_l - z0Local;
+                const double y_pred = outP[0] + outP[1]*zRel + outP[2]*kernelY[h];
+                const double res    = (y_h - y_pred) / smear_mm;
+                chi2 += res*res;
+            }
+            return chi2;
+        };
+
+        // --- Phase 2: station-level combinatorial flip using physics model ---
+        // The per-station scan finds the best intra-station L/R, but may pick the
+        // "mirror" orientation (all hits flipped) for an entire station.  With 4
+        // stations there are only 2^4=16 inter-station sign combos to try, so we
+        // can exhaustively test all of them with the full 3-parameter model.
+        // Flipping per-station (not per-hit) preserves intra-station consistency.
+        {
+            // Build station index lists into resolvedEventHits.
+            std::vector<int> stationOfHit(N);
+            std::vector<int> stationIds;
+            {
+                std::map<int, int> staIdx;
+                for (int h = 0; h < N; ++h) {
+                    int sta = resolvedEventHits[h].sta;
+                    if (staIdx.find(sta) == staIdx.end()) {
+                        staIdx[sta] = static_cast<int>(stationIds.size());
+                        stationIds.push_back(sta);
+                    }
+                    stationOfHit[h] = staIdx[sta];
+                }
+            }
+            const int nSta = static_cast<int>(stationIds.size());
+            // Save baseline per-station sides.
+            std::vector<int> baseSide(N);
+            for (int h = 0; h < N; ++h) baseSide[h] = resolvedEventHits[h].assignedSide;
+
+            double bestStaChi2 = 1e18;
+            std::vector<int> bestStaSide = baseSide;
+            const int nStaCombos = 1 << nSta;
+            for (int combo = 0; combo < nStaCombos; ++combo) {
+                for (int h = 0; h < N; ++h) {
+                    const int flip = ((combo >> stationOfHit[h]) & 1) ? -1 : 1;
+                    resolvedEventHits[h].assignedSide = baseSide[h] * flip;
+                }
+                double tryP[3]={};
+                double tryChi2 = fitAndChi2(tryP);
+                if (tryChi2 < bestStaChi2) {
+                    bestStaChi2 = tryChi2;
+                    for (int h = 0; h < N; ++h)
+                        bestStaSide[h] = resolvedEventHits[h].assignedSide;
+                }
+            }
+            for (int h = 0; h < N; ++h)
+                resolvedEventHits[h].assignedSide = bestStaSide[h];
+
+            std::cout << "[ReconstructMDT] Station-flip scan done: chi2=" << bestStaChi2
+                      << " nSta=" << nSta << " combos=" << nStaCombos << " hits=" << N << "\n";
+        }
+
+        // --- Phase 3: single-pass per-hit L/R guided by Phase 2 prediction ---
+        // Use the Phase 2 model prediction to assign each hit's L/R: +1 if
+        // y_pred >= y_wire, -1 otherwise.  Single pass only — iteration causes
+        // oscillation as the model shifts with each assignment change.
+        {
+            double p2P[3]={};
+            fitAndChi2(p2P);
+            for (int h = 0; h < N; ++h) {
+                const double zRel   = resolvedEventHits[h].wz_l - z0Local;
+                const double y_pred = p2P[0] + p2P[1]*zRel + p2P[2]*kernelY[h];
+                resolvedEventHits[h].assignedSide = (y_pred >= resolvedEventHits[h].wy_l) ? 1 : -1;
+            }
+            double p3P[3]={};
+            double p3Chi2 = fitAndChi2(p3P);
+            std::cout << "[ReconstructMDT] Per-hit guided refinement: chi2=" << p3Chi2 << "\n";
+        }
+
+        // ---------------------------------------------------------------------
+        // Analytic local y(z) fit using refined L/R assignment.
+        // (kernelY already computed above)
+        // ---------------------------------------------------------------------
         double ATA[3][3] = {};
         double ATy[3] = {};
         for (int h = 0; h < N; ++h) {
@@ -4263,11 +4415,17 @@ void TPORecoEvent::ReconstructMDT()
         // run GenFit track fitting
         // verbose = 1 for debug prints, 0 for quiet
         // GenFit expects momentum in GeV/c
-        const double seedPForGenFit = (pAnalytic > 0.0 && std::isfinite(pAnalytic))
-                                    ? pAnalytic
-                                    : seedMomentumGeV;
+	// Only reject sub-1-GeV pAnalytic values as degenerate (sagitta floor artifact).
+        // Values 1-1000 GeV are valid seeds even if they may be imprecise.
+        const double seedPForGenFit =
+            (pAnalytic >= 1.0 && pAnalytic <= 1000.0 && std::isfinite(pAnalytic))
+            ? pAnalytic
+            : seedMomentumGeV;
 
+ 
+        trk.fpAnalytic = pAnalytic;
         const bool ok = trk.GenFitMDTFit(meas, mdt->fPDG, seedPForGenFit, 1 /*verbose*/);
+        trk.ffit_ok = ok;
         if (ok) {
             std::cout << "[ReconstructMDT] GenFit Kalman SUCCESS:"
                       << " trackID=" << trk.ftrackID
@@ -4276,12 +4434,11 @@ void TPORecoEvent::ReconstructMDT()
                       << " chi2=" << trk.fchi2
                       << " ndf=" << trk.fnDoF
                       << std::endl;
-
-            fMuTracks.push_back(trk);
+        } else {
+            std::cout << "[ReconstructMDT] GenFit Kalman FAILED for trackID=" << trk.ftrackID
+                      << " pAnalytic=" << pAnalytic << " GeV/c" << std::endl;
         }
-        else {
-            std::cout << "[ReconstructMDT] GenFit Kalman FAILED for trackID=" << trk.ftrackID << std::endl;
-        }
+        fMuTracks.push_back(trk);
     }
 }
 /////////////////////////////////////


### PR DESCRIPTION
GenFit track fitting for the MDT geometry was failing for a large fraction of events. The following changes were introduced to improve the reconstruction:
- Added SetupMDTMagneticField() to determine the actual line of sight from the magnet-center coordinates and configure the magnetic field accordingly.
- Improved the left/right ambiguity resolution by introducing a three-phase selection algorithm.
- Increased the minimum number of hits required for fitting from 5 to 6, corresponding to at least two complete MDT stations with three hits each.
- Replaced the use of isFitConverged() as the final fit-validity criterion with a check based on getFittedState().
The last change was necessary because isFitConverged() was found to behave inconsistently across GenFit versions on macOS and LXPLUS. In LXPLUS, GenFit returned an excellent fitted track, for example with chi2/ndf≈0.24, while isFitConverged() still returned false. The fitted state is extracted directly after the fit and used to determine whether a valid solution is available.