### PR TITLE
improve further the Fitting MDT tracks

### DIFF
--- a/CoreUtils/GenMagneticField.hh
+++ b/CoreUtils/GenMagneticField.hh
@@ -111,24 +111,34 @@ private:
         }
         /////////////////////////////////////////
         // Dedicated MDT magnet field.
-        // GenFit position is in cm. gGeoManager also uses cm.
-        if (gGeoManager) {
-            TGeoNode* node = gGeoManager->FindNode(position.X(), position.Y(), position.Z());
-            if (node) {
-                std::string nodeName = node->GetName() ? node->GetName() : "";
-                if (nodeName.find("MDTMagnet") != std::string::npos) {
-                    // Convert to local-like transverse coordinate.
-                    // position.Y() is cm, slitposition is cm.
-                    double y_local_cm = position.Y() - rearMuSpec_LOS_shiftY;
-                    if (std::abs(y_local_cm) >= slitposition &&
-                        std::abs(y_local_cm) <= 2.0 * slitposition) {
-                        return TVector3(+15.0, 0.0, 0.0); // +1.5 T = +15 kG
-                    }
-                    if (std::abs(y_local_cm) < slitposition) {
-                        return TVector3(-15.0, 0.0, 0.0); // -1.5 T = -15 kG
-                    }
-                    return TVector3(0.0, 0.0, 0.0);
+        // Uses precomputed global z-ranges (set once per event via
+        // SetMDTMagnetZRangesCm) instead of a live gGeoManager->FindNode()
+        // lookup: see the comment on SetMDTMagnetZRangesCm for why a live
+        // lookup here is unsafe during GenFit propagation.
+        for (const auto& rng : mdt_magnet_z_ranges_cm_) {
+            if (z_cm > rng.first && z_cm < rng.second) {
+                // Convert to local-like transverse coordinate.
+                // position.Y() is cm, slitposition is cm.
+                double y_local_cm = position.Y() - rearMuSpec_LOS_shiftY;
+                const double y_abs = std::abs(y_local_cm);
+                // Smooth the central/outer field boundary with a 1 cm linear ramp
+                // to avoid a step-function discontinuity that can destabilise the
+                // Runge-Kutta integrator for tracks near |y_local|=slitposition.
+                const double ramp_half = 0.5; // ±0.5 cm = 1 cm total transition
+                const double lo = slitposition - ramp_half;
+                const double hi = slitposition + ramp_half;
+                if (y_abs < lo) {
+                    return TVector3(-15.0, 0.0, 0.0); // central: -1.5 T
                 }
+                if (y_abs < hi) {
+                    // Linear ramp from -15 kG to +15 kG
+                    double t = (y_abs - lo) / (2.0 * ramp_half);
+                    return TVector3(-15.0 + 30.0 * t, 0.0, 0.0);
+                }
+                if (y_abs <= 2.0 * slitposition) {
+                    return TVector3(+15.0, 0.0, 0.0); // outer: +1.5 T
+                }
+                return TVector3(0.0, 0.0, 0.0);
             }
         }
 

--- a/CoreUtils/TMuTrack.cc
+++ b/CoreUtils/TMuTrack.cc
@@ -337,9 +337,10 @@ void TMuTrack::CircleFitTaubin(int verbose, double detectorResolutionPSmm) {
 }
 /////////////////////////////////////////////////
 bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
-                            int pdg, 
+                            int pdg,
                             double seedMomentumGeV,
-                            int verbose)
+                            int verbose,
+                            double seedSlopeDyDz)
 {
     if (meas.size() < 5) {
         if (verbose > 0)
@@ -372,27 +373,39 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     if (mdtW.Mag() > 0.0) mdtW = mdtW.Unit();
     else mdtW = mdtU.Cross(mdtV).Unit();
 
-    // Seed position: arbitrary point on first measured MDT line.
-    // Important point: local X is unmeasured.
-    TVector3 posSeed(sortedMeas.front().x_mm * 0.1,
+    // Seed position: X=0 because B=(Bx,0,0) → Fx=0 → X is conserved.
+    // The 1D measurement constrains only Y at each Z; X is never measured,
+    // so GenFit's propagator stays at X=0 throughout (avoiding material
+    // corrections from traversing the MDT tube walls at global X≈900mm).
+    TVector3 posSeed(0.0,
                      sortedMeas.front().y_mm * 0.1,
                      sortedMeas.front().z_mm * 0.1); // cm
 
-    // Seed direction from measured local Y-Z trajectory.
-    // No local-X information exists, so assume dx_local/dz_local = 0.
-    const double dy_mm = sortedMeas.back().localY_mm - sortedMeas.front().localY_mm;
-    const double dz_mm = sortedMeas.back().localZ_mm - sortedMeas.front().localZ_mm;
-
+    // Seed direction: prefer analytic initial slope (dY/dZ at z0) when provided,
+    // because the hit-derived average slope absorbs the full magnetic bend,
+    // making the seed slope equal to the mid-trajectory slope rather than the
+    // true initial slope — which causes GenFit to reject stations 2-4 as outliers.
     TVector3 dirGlobal;
-
-    if (std::fabs(dy_mm) > 1.0e-12 || std::fabs(dz_mm) > 1.0e-12) { 
-        dirGlobal = mdtU * dy_mm + mdtW * dz_mm;
+    if (std::isfinite(seedSlopeDyDz)) {
+        // Build direction from analytic slope: dY/dZ in local MDT frame.
+        // dz component = 1 (normalized later), dy component = slope.
+        dirGlobal = mdtU * seedSlopeDyDz + mdtW;
         if (dirGlobal.Mag() > 0.0)
             dirGlobal = dirGlobal.Unit();
         else
             dirGlobal = mdtW;
     } else {
-        dirGlobal = mdtW;
+        const double dy_mm = sortedMeas.back().localY_mm - sortedMeas.front().localY_mm;
+        const double dz_mm = sortedMeas.back().localZ_mm - sortedMeas.front().localZ_mm;
+        if (std::fabs(dy_mm) > 1.0e-12 || std::fabs(dz_mm) > 1.0e-12) {
+            dirGlobal = mdtU * dy_mm + mdtW * dz_mm;
+            if (dirGlobal.Mag() > 0.0)
+                dirGlobal = dirGlobal.Unit();
+            else
+                dirGlobal = mdtW;
+        } else {
+            dirGlobal = mdtW;
+        }
     }
 
     const double pSeed =
@@ -400,7 +413,8 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
       ? seedMomentumGeV
       : 10.0;
 
-    TVector3 momSeed = dirGlobal * pSeed;
+    // px=0: no X force, so X-momentum stays negligible.
+    TVector3 momSeed(0.0, dirGlobal.Y() * pSeed, dirGlobal.Z() * pSeed);
 
     if (verbose > 0) {
         std::cout << "[GenFitMDTFit] seed pos cm = "
@@ -436,69 +450,6 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
 
     genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pdg);
 
-    /*
-    // Calculate average wire X position for field propagation
-    // We need GenFit to propagate through the magnet volumes (at wire X),
-    // but measurements should only constrain Y (from drift), not X position
-    double avgWireX_cm = 0.0;
-    for (const auto& m : sortedMeas) {
-        avgWireX_cm += m.wireX_mm;
-    }
-    avgWireX_cm = (avgWireX_cm / sortedMeas.size()) * 0.1;  // Convert to cm
-    
-    double seedX_cm = avgWireX_cm;                    // Average wire X for field propagation
-    double seedY_cm = sortedMeas[0].y_mm * 0.1;       // Resolved hit Y
-    double seedZ_cm = sortedMeas[0].wireZ_mm * 0.1;   // Wire center Z
-
-    TVector3 posSeed(seedX_cm, seedY_cm, seedZ_cm);
-
-    // Use FIXED 10 GeV seed (more stable than analytic 60 GeV)
-    TVector3 momSeed(0.0, 0.0, 10.0);  // Fixed 10 GeV along +Z
-    
-    if (verbose > 0) {
-        std::cout << "[GenFitMDTFit] Average wire X = " << avgWireX_cm << " cm\n";
-    }
-
-    if (verbose > 1) {
-        std::cout << "[GenFitMDTFit] gGeoManager = " << gGeoManager << std::endl;
-        if (gGeoManager && gGeoManager->GetTopVolume()) {
-            std::cout << "[GenFitMDTFit] Geometry top volume = "
-                    << gGeoManager->GetTopVolume()->GetName()
-                    << std::endl;
-        }
-        auto* field = genfit::FieldManager::getInstance()->getField();
-        std::cout << "[GenFitMDTFit] Field pointer = " << field << std::endl;
-        for (const auto& m : sortedMeas) {
-            TVector3 pos_cm(m.x_mm/10.0, m.y_mm/10.0, m.z_mm/10.0);
-            TVector3 BkG = field ? field->get(pos_cm) : TVector3(0,0,0);
-            TGeoNode* node = nullptr;
-            const char* matName = "NULL";
-            if (gGeoManager) {
-                node = gGeoManager->FindNode(pos_cm.X(), pos_cm.Y(), pos_cm.Z());
-                if (node && node->GetVolume() && node->GetVolume()->GetMedium()) {
-                    matName = node->GetVolume()->GetMedium()->GetMaterial()->GetName();
-                }
-            }
-            std::cout << Form(
-                "[GenFitMDTFit] z=%+.1f mm  B=(%+.2f,%+.2f,%+.2f) kG  material=%s",
-                m.z_mm, BkG.X(), BkG.Y(), BkG.Z(), matName
-            ) << std::endl;
-        }
-    }
-    if (verbose > 0) {
-        std::cout << "[GenFitMDTFit] seed pos cm = "
-                  << posSeed.X() << " "
-                  << posSeed.Y() << " "
-                  << posSeed.Z() << "\n";
-        std::cout << "[GenFitMDTFit] seed mom GeV = "
-                  << momSeed.X() << " "
-                  << momSeed.Y() << " "
-                  << momSeed.Z() << "\n";
-        std::cout << "[GenFitMDTFit] First hit: y_mm=" << sortedMeas[0].y_mm 
-                  << " wireZ_mm=" << sortedMeas[0].wireZ_mm 
-                  << " z_mm=" << sortedMeas[0].z_mm << "\n";
-    }
-*/
     // Pack the parameters into GenFit's combined 6D TVectorD seed state vector
     TVectorD stateSeed(6);
     stateSeed(0) = posSeed.X(); 
@@ -508,70 +459,44 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     stateSeed(4) = momSeed.Y(); 
     stateSeed(5) = momSeed.Z();
 
-    // Configure the prior 6x6 uncertainty covariance state constraint matrix
+    // Simple diagonal covariance in global Cartesian (X,Y,Z,px,py,pz).
+    // X is conserved (Fx=0), so position uncertainty is symmetric; use 1 cm each.
     TMatrixDSym covSeed(6);
     covSeed.Zero();
-    // Position covariance.
-    // MDT measures local Y, knows local Z plane, but does not measure local X.
-    const double sigmaU_cm = 0.2;   // local Y seed uncertainty
-    const double sigmaW_cm = 0.2;   // local Z seed uncertainty
-    const double sigmaV_cm = 30.0;  // local X/wire uncertainty; large
-
-    auto addPosCov = [&](const TVector3& axis, double sigma_cm) {
-        const double a[3] = { axis.X(), axis.Y(), axis.Z() };
-        for (int i = 0; i < 3; ++i) {
-            for (int j = 0; j < 3; ++j) {
-                covSeed(i,j) +=
-                    sigma_cm * sigma_cm * a[i] * a[j];
-            }
-        }
-    };
-    addPosCov(mdtU, sigmaU_cm);
-    addPosCov(mdtV, sigmaV_cm);
-    addPosCov(mdtW, sigmaW_cm);
-    // Momentum covariance.
-    // Keep this broad enough for Kalman convergence.
-    const double momSigma = std::max(10.0, 0.5 * pSeed);
-    covSeed(3,3) = momSigma * momSigma;
-    covSeed(4,4) = momSigma * momSigma;
-    covSeed(5,5) = momSigma * momSigma;
+    covSeed(0,0) = 1.0;    // (1 cm)^2 in X
+    covSeed(1,1) = 1.0;    // (1 cm)^2 in Y
+    covSeed(2,2) = 1.0;    // (1 cm)^2 in Z
+    const double momSigma = std::max(5.0, 0.5 * pSeed);
+    covSeed(3,3) = 1.0;                        // (1 GeV)^2 in px
+    covSeed(4,4) = 1.0;                        // (1 GeV)^2 in py
+    covSeed(5,5) = momSigma * momSigma;        // broader pz uncertainty
 
     // Instantiate the GenFit master track container.
     genfit::Track fitTrack(rep, stateSeed, covSeed);
 
-    // PlanarMeasurement with pre-resolved L/R from Phase 1-3.
-    // Using PlanarMeasurement (fixed planes) avoids the WireMeasurement dynamic-plane
-    // search that can accumulate > 3000 cm path length in the RK propagator.
-    // L/R is resolved externally (stored in hit.side and in hit.localY_mm = wire_y + side*r).
-    const double hitSigmaU_cm = 0.080 * 0.1; // 80 μm drift resolution in measured direction
-    const double hitSigmaV_cm = 10.0;         // wire direction: unmeasured (large)
-    TMatrixDSym hitCov(2);
-    hitCov.Zero();
-    hitCov(0,0) = hitSigmaU_cm * hitSigmaU_cm; // u = local Y (measured)
-    hitCov(1,1) = hitSigmaV_cm * hitSigmaV_cm; // v = local X (wire direction, unmeasured)
+    // 1D measurement: only global Y (drift direction) is measured.
+    // Global X is unmeasured and stays ~0 (no X force from B=(Bx,0,0)).
+    // Plane normal = hU×hV = (0,1,0)×(1,0,0) = (0,0,-1) → plane ⊥ Z, natural for MDT.
+    const double hitSigmaU_cm = 0.080 * 0.1; // 80 μm drift resolution in cm
+    TMatrixDSym hitCov1D(1);
+    hitCov1D.Zero();
+    hitCov1D(0,0) = hitSigmaU_cm * hitSigmaU_cm;
+    const TVector3 hU_global(0.0, 1.0, 0.0); // measured: global Y (drift direction)
+    const TVector3 hV_global(1.0, 0.0, 0.0); // unmeasured: global X (wire direction)
 
     const int detId = 0;
     int hitCounter = 0;
     for (const auto& hit : sortedMeas) {
-        // Per-hit local frame: u=localY(measured), v=localX(wire), w=localZ(normal to plane).
-        TVector3 hU(hit.uX, hit.uY, hit.uZ);
-        TVector3 hV(hit.vX, hit.vY, hit.vZ);
-        if (hU.Mag() > 0) hU = hU.Unit();
-        if (hV.Mag() > 0) hV = hV.Unit();
+        // X=0: no X force so particle stays at X=0 throughout.
+        TVector3 planeOrigin(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
 
-        // Plane origin = resolved hit position in global frame (x_mm, y_mm, z_mm).
-        // hitCoords = (0, 0) means the measurement is AT the plane origin.
-        // GenFit's Kalman residual = (track prediction at plane) - hitCoords.
-        TVector3 planeOrigin(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1);
-
-        TVectorD hitCoords(2);
-        hitCoords(0) = 0.0; // measurement at plane origin (u)
-        hitCoords(1) = 0.0; // v unmeasured
+        TVectorD hitCoords(1);
+        hitCoords(0) = 0.0; // measured Y = planeOrigin.Y() = hit.y_mm/10
 
         genfit::PlanarMeasurement* meas_pt = new genfit::PlanarMeasurement(
-            hitCoords, hitCov, detId, hitCounter, nullptr);
+            hitCoords, hitCov1D, detId, hitCounter, nullptr);
         meas_pt->setPlane(
-            genfit::SharedPlanePtr(new genfit::DetPlane(planeOrigin, hU, hV)),
+            genfit::SharedPlanePtr(new genfit::DetPlane(planeOrigin, hU_global, hV_global)),
             hitCounter);
         fitTrack.insertPoint(new genfit::TrackPoint(meas_pt, &fitTrack));
         ++hitCounter;
@@ -646,7 +571,7 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
         std::cerr << "[GenFitMDTFit] ====================================\n\n";
         return false;
     }
-
+    
     // isFitConverged() is unreliable across GenFit versions:
     // some versions return false even for excellent fits (chi2/NDF~0.24).
     // Instead: always try to extract the state and gate on chi2/NDF + pval.
@@ -668,13 +593,269 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
         return false;
     }
 
-     // Quality gate: chi2/NDF must be physically reasonable AND pval not catastrophic.
-    // chi2/NDF < 10 rejects runaway fits; pval > 1e-10 rejects wrong-minimum solutions.
-    const bool qualityOk = (fitNDF > 0) && (chi2ndf < 10.0) && (fitPval > 1e-10);
-    if (!qualityOk) {
-        std::cerr << "[GenFitMDTFit] REJECTED: chi2/NDF=" << chi2ndf
-                  << "  pval=" << fitPval << "\n";
-        return false;
+    // Quality gate: accept if GenFit declares convergence OR chi2/NDF is reasonable.
+    // With 1D global-axis measurements the fitter is numerically stable, so
+    // isFitConverged() is reliable.  Keep chi2/NDF < 100 as a safety backstop.
+    const bool qualityOk = status->isFitConverged() || ((fitNDF > 0) && (chi2ndf < 100.0));
+    // Also trigger retry if too many hits were silently rejected: a "converged" fit
+    // that keeps only 6 of 12 hits (NDF=1 vs expected NDF=7) is not acceptable.
+    const int expectedNDF = (int)sortedMeas.size() - 5;
+    const bool tooFewHits = (fitNDF > 0) && (fitNDF < expectedNDF - 3);
+    if (!qualityOk || tooFewHits) {
+        std::cerr << "[GenFitMDTFit] Attempt 1 rejected: chi2/NDF=" << chi2ndf
+                  << "  pval=" << fitPval
+                  << (tooFewHits ? "  (too few hits: NDF=" + std::to_string(fitNDF)
+                                   + " expected " + std::to_string(expectedNDF) + ")" : "")
+                  << " — trying L/R refinement\n";
+
+        // Use the partial track state to re-assign L/R hit-by-hit.
+        // The partial state is usually a good approximation of the true trajectory
+        // even when qualityOk=false.  Linear propagation is sufficient to determine
+        // which side of each wire the track passes.
+        TVector3 pPartial  = state.getMom();   // GeV/c, global
+        TVector3 posPartial = state.getPos();  // cm, global
+
+        if (pPartial.Mag() < 0.5) return false;
+
+        const double slopeYZ = (std::fabs(pPartial.Z()) > 0.01)
+                               ? pPartial.Y() / pPartial.Z() : 0.0;
+
+        int nFlipped = 0;
+        for (auto& m : sortedMeas) {
+            const double dz_cm   = m.z_mm * 0.1 - posPartial.Z();
+            const double yPred_mm = (posPartial.Y() + slopeYZ * dz_cm) * 10.0;
+            const int newSide    = (yPred_mm >= m.wireY_mm) ? 1 : -1;
+            if (newSide != m.side) {
+                ++nFlipped;
+                const int oldSide = m.side;
+                m.side        = newSide;
+                m.y_mm        = m.wireY_mm + newSide * m.r_meas_mm;
+                m.localY_mm  += (newSide - oldSide) * m.r_meas_mm;
+                // x_mm: small tilt correction (sin 4.5° ≈ 0.0785), skip for brevity
+            }
+        }
+
+        if (nFlipped == 0) return false;
+        std::cerr << "[GenFitMDTFit] " << nFlipped << " hit(s) L/R refined — retrying\n";
+
+        // Second GenFit attempt with corrected measurements, 1D global planes.
+        genfit::AbsTrackRep* rep2 = new genfit::RKTrackRep(pdg);
+
+        // Seed from partial state, zeroing X (conserved; keeps propagator at X=0).
+        TVectorD stateSeed2(6);
+        stateSeed2(0) = 0.0;            stateSeed2(1) = posPartial.Y(); stateSeed2(2) = posPartial.Z();
+        stateSeed2(3) = 0.0;            stateSeed2(4) = pPartial.Y();   stateSeed2(5) = pPartial.Z();
+        TMatrixDSym covSeed2(6); covSeed2.Zero();
+        for (int i = 0; i < 3; ++i) covSeed2(i,i) = 1.0;
+        const double mSig2 = std::max(5.0, 0.3 * pPartial.Mag());
+        covSeed2(3,3) = 1.0; covSeed2(4,4) = 1.0;
+        covSeed2(5,5) = mSig2 * mSig2;
+
+        genfit::Track fitTrack2(rep2, stateSeed2, covSeed2);
+
+        int hitCtr2 = 0;
+        for (const auto& hit : sortedMeas) {
+            TVector3 origin2(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
+            TVectorD hc2(1); hc2(0) = 0.0;
+            TMatrixDSym hCov2(1); hCov2.Zero();
+            hCov2(0,0) = hitSigmaU_cm * hitSigmaU_cm;
+            auto* mpt2 = new genfit::PlanarMeasurement(hc2, hCov2, 0, hitCtr2, nullptr);
+            mpt2->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(origin2, hU_global, hV_global)), hitCtr2);
+            fitTrack2.insertPoint(new genfit::TrackPoint(mpt2, &fitTrack2));
+            ++hitCtr2;
+        }
+
+        genfit::KalmanFitterRefTrack fitter2;
+        fitter2.setMaxIterations(10);
+        fitter2.setRelChi2Change(0.001);
+        try { fitter2.processTrack(&fitTrack2); }
+        catch (...) { std::cerr << "[GenFitMDTFit] Retry exception\n"; return false; }
+
+        genfit::FitStatus* status2 = fitTrack2.getFitStatus(rep2);
+        if (!status2) return false;
+
+        const double chi2_2    = status2->getChi2();
+        const double ndf_2     = status2->getNdf();
+        const double pval_2    = status2->getPVal();
+        const double chi2ndf_2 = (ndf_2 > 0) ? chi2_2 / ndf_2 : 1e9;
+
+        std::cerr << "[GenFitMDTFit] Retry: chi2/NDF=" << chi2ndf_2 << "  pval=" << pval_2 << "\n";
+
+        genfit::MeasuredStateOnPlane state2;
+        try { state2 = fitTrack2.getFittedState(); }
+        catch (...) { return false; }
+
+        const bool qualityOk2 = status2->isFitConverged() || ((ndf_2 > 0) && (chi2ndf_2 < 100.0));
+        if (!qualityOk2) {
+            // Attempt 3+: try multiple seed momenta (1D global planes throughout).
+            static const double altSeeds[] = { 5.0, 20.0, 100.0 };
+            for (double altP : altSeeds) {
+                genfit::AbsTrackRep* rep3 = new genfit::RKTrackRep(pdg);
+                TVectorD ss3(6);
+                // X=0 always; use Y/Z from analytic direction scaled to altP.
+                ss3(0) = 0.0; ss3(1) = posSeed.Y(); ss3(2) = posSeed.Z();
+                TVector3 d3(0.0, dirGlobal.Y() * altP, dirGlobal.Z() * altP);
+                ss3(3) = d3.X(); ss3(4) = d3.Y(); ss3(5) = d3.Z();
+                TMatrixDSym cs3(6); cs3.Zero();
+                for (int i = 0; i < 3; ++i) cs3(i,i) = 1.0;
+                const double ms3 = std::max(5.0, 0.3 * altP);
+                cs3(3,3) = 1.0; cs3(4,4) = 1.0; cs3(5,5) = ms3 * ms3;
+                genfit::Track ft3(rep3, ss3, cs3);
+                int hc3 = 0;
+                for (const auto& hit : sortedMeas) {
+                    TVector3 org3(0.0, hit.y_mm*0.1, hit.z_mm*0.1);
+                    TVectorD hc3v(1); hc3v(0) = 0.0;
+                    TMatrixDSym hCov3(1); hCov3.Zero();
+                    hCov3(0,0) = hitSigmaU_cm*hitSigmaU_cm;
+                    auto* mpt3 = new genfit::PlanarMeasurement(hc3v, hCov3, 0, hc3, nullptr);
+                    mpt3->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(org3, hU_global, hV_global)), hc3);
+                    ft3.insertPoint(new genfit::TrackPoint(mpt3, &ft3));
+                    ++hc3;
+                }
+                genfit::KalmanFitterRefTrack fitter3;
+                fitter3.setMaxIterations(10);
+                fitter3.setRelChi2Change(0.001);
+                try { fitter3.processTrack(&ft3); } catch (...) { continue; }
+                genfit::FitStatus* st3 = ft3.getFitStatus(rep3);
+                if (!st3) continue;
+                const double c3 = st3->getChi2(), n3 = st3->getNdf(), pv3 = st3->getPVal();
+                const double cn3 = (n3 > 0) ? c3/n3 : 1e9;
+                std::cerr << "[GenFitMDTFit] AltSeed " << altP << " GeV: chi2/NDF=" << cn3 << "  pval=" << pv3 << "\n";
+                if (!st3->isFitConverged() && ((n3 <= 0) || (cn3 >= 100.0))) continue;
+                genfit::MeasuredStateOnPlane st3s;
+                try { st3s = ft3.getFittedState(); } catch (...) { continue; }
+                TVector3 p3 = st3s.getMom();
+                fpx = p3.X(); fpy = p3.Y(); fpz = p3.Z(); fp = p3.Mag();
+                fcharge = st3s.getCharge();
+                fchi2 = c3; fnDoF = static_cast<int>(n3); fpval = pv3;
+                fQOverP = st3s.getState()(0);
+                fQOverPErr = std::sqrt(st3s.getCov()(0,0));
+                fpErr = fQOverPErr * fp * fp;
+                fpos.clear(); layerID.clear();
+                for (const auto& m : sortedMeas) {
+                    fpos.emplace_back(m.x_mm, m.y_mm, m.z_mm);
+                    layerID.push_back(m.stationID*10000 + m.planeID*1000 + m.tubeID);
+                }
+                std::cerr << "[GenFitMDTFit] AltSeed SUCCESS: p=" << fp << " q=" << fcharge << "\n";
+                return true;
+            }
+
+            // ── DAF rescue ────────────────────────────────────────────────────
+            // All Kalman attempts failed.  Try GenFit's Deterministic Annealing
+            // Filter which soft-weights each hit by its chi² contribution and
+            // iteratively cools the temperature, driving contaminated hits (from
+            // a secondary particle or a misidentified MDT tube) to weight → 0.
+            // The muon track then emerges from the uncontaminated majority.
+            {
+                genfit::AbsTrackRep* repD = new genfit::RKTrackRep(pdg);
+                TVectorD ssD(6);
+                ssD(0) = 0.0; ssD(1) = posSeed.Y(); ssD(2) = posSeed.Z();
+                TVector3 dD(0.0, dirGlobal.Y() * seedMomentumGeV,
+                                 dirGlobal.Z() * seedMomentumGeV);
+                ssD(3) = dD.X(); ssD(4) = dD.Y(); ssD(5) = dD.Z();
+                TMatrixDSym csD(6); csD.Zero();
+                for (int i = 0; i < 3; ++i) csD(i,i) = 1.0;
+                const double msD = std::max(5.0, 0.3 * seedMomentumGeV);
+                csD(3,3) = 1.0; csD(4,4) = 1.0; csD(5,5) = msD * msD;
+
+                genfit::Track ftD(repD, ssD, csD);
+                int hcD = 0;
+                for (const auto& hit : sortedMeas) {
+                    TVector3 orgD(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
+                    TVectorD hcDv(1); hcDv(0) = 0.0;
+                    TMatrixDSym hCovD(1); hCovD.Zero();
+                    hCovD(0,0) = hitSigmaU_cm * hitSigmaU_cm;
+                    auto* mptD = new genfit::PlanarMeasurement(hcDv, hCovD, 0, hcD, nullptr);
+                    mptD->setPlane(genfit::SharedPlanePtr(
+                        new genfit::DetPlane(orgD, hU_global, hV_global)), hcD);
+                    ftD.insertPoint(new genfit::TrackPoint(mptD, &ftD));
+                    ++hcD;
+                }
+
+                genfit::DAF daf;
+                // T_start=1e7: even a hit 1000σ from the seed (chi2=1e6) gets
+                // initial weight exp(-1e6/(2e7))=exp(-0.05)≈0.95 — all hits are
+                // included at the start regardless of how wrong the seed is.
+                // T_stop=9: final cut ≈3σ for a 1D measurement, cleanly rejects
+                // contaminated hits that converge far from the muon track.
+                daf.setAnnealingScheme(1e7, 9.0, 30);
+                daf.setMaxIterations(60);
+
+                try { daf.processTrack(&ftD); }
+                catch (...) {
+                    std::cerr << "[GenFitMDTFit] DAF exception\n";
+                    return false;
+                }
+
+                genfit::FitStatus* stD = ftD.getFitStatus(repD);
+                if (!stD) return false;
+
+                const double cD  = stD->getChi2();
+                const double nD  = stD->getNdf();
+                const double pvD = stD->getPVal();
+                const double cnD = (nD > 0) ? cD / nD : 1e9;
+
+                std::cerr << "[GenFitMDTFit] DAF: isFitConverged="
+                          << (stD->isFitConverged() ? "YES" : "NO")
+                          << "  chi2/NDF=" << cnD << "  NDF=" << nD
+                          << "  pval=" << pvD << "\n";
+
+                // Accept DAF result if converged or chi2/NDF is reasonable.
+                // Use a looser threshold (200) than Kalman (100): DAF NDF is
+                // an effective (weighted) quantity and chi2 from upweighted good
+                // hits is usually clean, but a few partially-weighted boundary
+                // hits can inflate the ratio slightly.
+                // Require effective NDF >= 1 (at least one hit with significant
+                // weight survived annealing) and physical momentum (< 10 TeV).
+                const bool qualityDAF = (stD->isFitConverged() || ((nD > 0) && (cnD < 200.0)))
+                                        && (nD >= 1.0) && (cnD < 200.0);
+                if (!qualityDAF) return false;
+
+                genfit::MeasuredStateOnPlane stDs;
+                try { stDs = ftD.getFittedState(); }
+                catch (...) { return false; }
+
+                TVector3 pD = stDs.getMom();
+                fpx = pD.X(); fpy = pD.Y(); fpz = pD.Z(); fp = pD.Mag();
+                fcharge    = stDs.getCharge();
+                fchi2      = cD;
+                fnDoF      = static_cast<int>(nD);
+                fpval      = pvD;
+                fQOverP    = stDs.getState()(0);
+                fQOverPErr = std::sqrt(stDs.getCov()(0,0));
+                fpErr      = fQOverPErr * fp * fp;
+                fpos.clear(); layerID.clear();
+                for (const auto& m : sortedMeas) {
+                    fpos.emplace_back(m.x_mm, m.y_mm, m.z_mm);
+                    layerID.push_back(m.stationID * 10000 + m.planeID * 1000 + m.tubeID);
+                }
+                std::cerr << "[GenFitMDTFit] DAF SUCCESS: p=" << fp
+                          << " q=" << fcharge << " chi2/NDF=" << cnD
+                          << " NDF=" << nD << "\n";
+                return true;
+            }
+            // ── end DAF rescue ────────────────────────────────────────────────
+        }
+
+        // Accept retry result
+        TVector3 p2 = state2.getMom();
+        fpx = p2.X(); fpy = p2.Y(); fpz = p2.Z(); fp = p2.Mag();
+        fcharge    = state2.getCharge();
+        fchi2      = chi2_2;
+        fnDoF      = static_cast<int>(ndf_2);
+        fpval      = pval_2;
+        fQOverP    = state2.getState()(0);
+        fQOverPErr = std::sqrt(state2.getCov()(0,0));
+        fpErr      = fQOverPErr * fp * fp;
+        fpos.clear(); layerID.clear();
+        for (const auto& m : sortedMeas) {
+            fpos.emplace_back(m.x_mm, m.y_mm, m.z_mm);
+            layerID.push_back(m.stationID * 10000 + m.planeID * 1000 + m.tubeID);
+        }
+        if (verbose)
+            std::cout << "[GenFitMDTFit] Retry SUCCESS: p=" << fp
+                      << " q=" << fcharge << " chi2/NDF=" << chi2ndf_2 << "\n";
+        return true;
     }
     TVector3 pfit = state.getMom();
     fpx = pfit.X();

--- a/CoreUtils/TMuTrack.hh
+++ b/CoreUtils/TMuTrack.hh
@@ -1,6 +1,7 @@
 #ifndef _TMUTRACK_
 #define _TMUTRACK_ 1
 
+#include <limits>
 #include <TObject.h>
 #include <Math/Vector3D.h>
 #include <TVector3.h>
@@ -61,8 +62,8 @@ public:
 
     bool   ffit_ok;     // true if GenFit Kalman converged
     double fpAnalytic;  // analytic sagitta-fit momentum (GeV/c), always filled
-   
-    TMuTrack() : ftrackID(-1), fcharge(0), fitTrack(nullptr) {}
+    
+    TMuTrack() : ftrackID(-1), fcharge(0), fitTrack(nullptr), ffit_ok(false), fpAnalytic(0.0) {}
     virtual ~TMuTrack() {
         if (fitTrack) {
             delete fitTrack;
@@ -84,7 +85,7 @@ public:
 
     /// @brief Use GenFit to fit the track
     void GenFitTrackFit(int verbose, double detectorResolutionPSmm);
-    bool GenFitMDTFit(const std::vector<MDTMeas>& meas, int pdg, double seedMomentumGeV = 10.0, int verbose = 0);
+    bool GenFitMDTFit(const std::vector<MDTMeas>& meas, int pdg, double seedMomentumGeV = 10.0, int verbose = 0, double seedSlopeDyDz = std::numeric_limits<double>::quiet_NaN());
     
     
     // ////////    ///////////

--- a/CoreUtils/TPORecoEvent.cc
+++ b/CoreUtils/TPORecoEvent.cc
@@ -4049,9 +4049,8 @@ void TPORecoEvent::ReconstructMDT()
     // Configure MDT magnet z-ranges on the field so ComputeYKernelFromBx and GenFit see non-zero B.
     SetupMDTMagneticField(fMagField, fTcalEvent);
     ///////////////////////////////////
-    // Set up a random engine to smear the true drift radius into a measured one
-    std::random_device rd;
-    //std::mt19937 muon_rng(rd());
+    // Set up a random engine to smear the true drift radius into a measured one.
+    // Fixed seed ensures reproducible L/R assignments across platforms and runs.
     std::mt19937 muon_rng(42);
     auto smearRadius = [&](double r_true) {
         std::normal_distribution<double> gaussR(0.0, smear_mm);
@@ -4147,7 +4146,9 @@ void TPORecoEvent::ReconstructMDT()
         //   chi2. Repeat up to 5 passes or until no flip improves chi2.
         // ---------------------------------------------------------------------
 
-        // --- Phase 1: per-station straight-line L/R scan ---
+        // --- Phase 1: collect hits, group by station ---
+        // L/R is NOT assigned here; a global combinatorial search below finds the
+        // optimal assignment using the full physics (kernelY bending) model.
         std::vector<Hit> resolvedEventHits;
         for (auto& pair : stationGroups) {
             auto& sHits = pair.second;
@@ -4158,35 +4159,8 @@ void TPORecoEvent::ReconstructMDT()
                           << " has " << nH << " hits; skipping track.\n";
                 resolvedEventHits.clear(); break;
             }
-            double bestLocalChi2 = 1e18;
-            std::vector<int> bestSides(nH, 1);
-            for (int combo = 0; combo < (1 << nH); ++combo) {
-                double sumZ=0, sumZ2=0, sumY=0, sumZY=0;
-                for (int i = 0; i < nH; ++i) {
-                    const int s = ((combo>>i)&1) ? 1 : -1;
-                    const double y = sHits[i].wy_l + s * sHits[i].r;
-                    const double z = sHits[i].wz_l;
-                    sumZ+=z; sumZ2+=z*z; sumY+=y; sumZY+=z*y;
-                }
-                const double denom = nH*sumZ2 - sumZ*sumZ;
-                if (std::fabs(denom) < 1e-6) continue;
-                const double slope  = (nH*sumZY - sumZ*sumY) / denom;
-                const double intcpt = (sumY - slope*sumZ) / nH;
-                double chi2 = 0;
-                for (int i = 0; i < nH; ++i) {
-                    const int s = ((combo>>i)&1) ? 1 : -1;
-                    const double res = sHits[i].wy_l + s*sHits[i].r
-                                       - (intcpt + slope*sHits[i].wz_l);
-                    chi2 += res*res / (smear_mm*smear_mm);
-                }
-                if (chi2 < bestLocalChi2) {
-                    bestLocalChi2 = chi2;
-                    for (int i = 0; i < nH; ++i)
-                        bestSides[i] = ((combo>>i)&1) ? 1 : -1;
-                }
-            }
             for (int i = 0; i < nH; ++i) {
-                sHits[i].assignedSide = bestSides[i];
+                sHits[i].assignedSide = 1;  // placeholder; overwritten by combo scan below
                 resolvedEventHits.push_back(sHits[i]);
             }
         }
@@ -4240,71 +4214,59 @@ void TPORecoEvent::ReconstructMDT()
             return chi2;
         };
 
-        // --- Phase 2: station-level combinatorial flip using physics model ---
-        // The per-station scan finds the best intra-station L/R, but may pick the
-        // "mirror" orientation (all hits flipped) for an entire station.  With 4
-        // stations there are only 2^4=16 inter-station sign combos to try, so we
-        // can exhaustively test all of them with the full 3-parameter model.
-        // Flipping per-station (not per-hit) preserves intra-station consistency.
+        // --- Phase 2: Per-station local straight-line L/R assignment ---
+        // Within each station (~3 layers, ~80mm z-spread) curvature is negligible.
+        // Enumerate all 2^nHits combos per station, pick the one with smallest
+        // straight-line chi2.  This mirrors the reference reco_mdt_genfit_batch.cc
+        // approach (solveLocalStationLR) and is far more robust than a global
+        // combinatorial that can be confused by contaminating hits.
         {
-            // Build station index lists into resolvedEventHits.
-            std::vector<int> stationOfHit(N);
-            std::vector<int> stationIds;
-            {
-                std::map<int, int> staIdx;
-                for (int h = 0; h < N; ++h) {
-                    int sta = resolvedEventHits[h].sta;
-                    if (staIdx.find(sta) == staIdx.end()) {
-                        staIdx[sta] = static_cast<int>(stationIds.size());
-                        stationIds.push_back(sta);
-                    }
-                    stationOfHit[h] = staIdx[sta];
-                }
-            }
-            const int nSta = static_cast<int>(stationIds.size());
-            // Save baseline per-station sides.
-            std::vector<int> baseSide(N);
-            for (int h = 0; h < N; ++h) baseSide[h] = resolvedEventHits[h].assignedSide;
-
-            double bestStaChi2 = 1e18;
-            std::vector<int> bestStaSide = baseSide;
-            const int nStaCombos = 1 << nSta;
-            for (int combo = 0; combo < nStaCombos; ++combo) {
-                for (int h = 0; h < N; ++h) {
-                    const int flip = ((combo >> stationOfHit[h]) & 1) ? -1 : 1;
-                    resolvedEventHits[h].assignedSide = baseSide[h] * flip;
-                }
-                double tryP[3]={};
-                double tryChi2 = fitAndChi2(tryP);
-                if (tryChi2 < bestStaChi2) {
-                    bestStaChi2 = tryChi2;
-                    for (int h = 0; h < N; ++h)
-                        bestStaSide[h] = resolvedEventHits[h].assignedSide;
-                }
-            }
+            std::map<int, std::vector<int>> stationHitIdx;
             for (int h = 0; h < N; ++h)
-                resolvedEventHits[h].assignedSide = bestStaSide[h];
+                stationHitIdx[resolvedEventHits[h].sta].push_back(h);
 
-            std::cout << "[ReconstructMDT] Station-flip scan done: chi2=" << bestStaChi2
-                      << " nSta=" << nSta << " combos=" << nStaCombos << " hits=" << N << "\n";
-        }
+            const double sigma2 = smear_mm * smear_mm;
+            for (auto& [sta, idxVec] : stationHitIdx) {
+                const int nh = static_cast<int>(idxVec.size());
+                const int nCombos = 1 << nh;
+                double bestChi2Local = 1e18;
+                std::vector<int> bestSidesLocal(nh, 1);
 
-        // --- Phase 3: single-pass per-hit L/R guided by Phase 2 prediction ---
-        // Use the Phase 2 model prediction to assign each hit's L/R: +1 if
-        // y_pred >= y_wire, -1 otherwise.  Single pass only — iteration causes
-        // oscillation as the model shifts with each assignment change.
-        {
-            double p2P[3]={};
-            fitAndChi2(p2P);
-            for (int h = 0; h < N; ++h) {
-                const double zRel   = resolvedEventHits[h].wz_l - z0Local;
-                const double y_pred = p2P[0] + p2P[1]*zRel + p2P[2]*kernelY[h];
-                resolvedEventHits[h].assignedSide = (y_pred >= resolvedEventHits[h].wy_l) ? 1 : -1;
+                for (int combo = 0; combo < nCombos; ++combo) {
+                    double sumZ=0, sumZ2=0, sumY=0, sumZY=0;
+                    std::vector<double> ys(nh);
+                    for (int i = 0; i < nh; ++i) {
+                        const Hit& hit = resolvedEventHits[idxVec[i]];
+                        int side = ((combo >> i) & 1) ? 1 : -1;
+                        double y = hit.wy_l + side * hit.r;
+                        double z = hit.wz_l;
+                        ys[i] = y;
+                        sumZ += z; sumZ2 += z*z; sumY += y; sumZY += z*y;
+                    }
+                    double denom = nh * sumZ2 - sumZ * sumZ;
+                    if (std::fabs(denom) < 1e-6) continue;
+                    double slope     = (nh * sumZY - sumZ * sumY) / denom;
+                    double intercept = (sumY - slope * sumZ) / nh;
+                    double chi2 = 0;
+                    for (int i = 0; i < nh; ++i) {
+                        const Hit& hit = resolvedEventHits[idxVec[i]];
+                        double res = ys[i] - (intercept + slope * hit.wz_l);
+                        chi2 += res*res / sigma2;
+                    }
+                    if (chi2 < bestChi2Local) {
+                        bestChi2Local = chi2;
+                        for (int i = 0; i < nh; ++i)
+                            bestSidesLocal[i] = ((combo >> i) & 1) ? 1 : -1;
+                    }
+                }
+                for (int i = 0; i < nh; ++i)
+                    resolvedEventHits[idxVec[i]].assignedSide = bestSidesLocal[i];
+                std::cout << "[ReconstructMDT] Station " << sta
+                          << " local L/R: chi2=" << bestChi2Local
+                          << " nHits=" << nh << "\n";
             }
-            double p3P[3]={};
-            double p3Chi2 = fitAndChi2(p3P);
-            std::cout << "[ReconstructMDT] Per-hit guided refinement: chi2=" << p3Chi2 << "\n";
         }
+
 
         // ---------------------------------------------------------------------
         // Analytic local y(z) fit using refined L/R assignment.
@@ -4327,7 +4289,175 @@ void TPORecoEvent::ReconstructMDT()
             std::cout << "[ReconstructMDT] Solve3 matrix inversion failed for track "<< tid << std::endl;
             continue;
         }
- 
+
+        // Iterative global L/R refinement: use the analytic trajectory from bestP
+        // to reassign each hit's L/R side, then refit.  Per-station assignment
+        // (Phase 2 above) minimises intra-station chi2 independently per station,
+        // which can leave a few hits on the wrong side when the global bending makes
+        // one side locally and globally inconsistent.  3-4 global passes converge.
+        for (int iter = 0; iter < 4; ++iter) {
+            int nFlipped = 0;
+            for (int h = 0; h < N; ++h) {
+                auto& hit = resolvedEventHits[h];
+                const double zRel = hit.wz_l - z0Local;
+                const double yPred = bestP[0] + bestP[1] * zRel + bestP[2] * kernelY[h];
+                const int newSide = (yPred >= hit.wy_l) ? 1 : -1;
+                if (newSide != hit.assignedSide) {
+                    hit.assignedSide = newSide;
+                    ++nFlipped;
+                }
+            }
+            if (nFlipped == 0) break; // converged
+            // Recompute analytic fit with updated L/R
+            double ATA2[3][3] = {};
+            double ATy2[3] = {};
+            for (int h = 0; h < N; ++h) {
+                const auto& hit = resolvedEventHits[h];
+                const double y_assigned = hit.wy_l + hit.assignedSide * hit.r;
+                const double zRel = hit.wz_l - z0Local;
+                double A[3] = {1.0, zRel, kernelY[h]};
+                for (int i = 0; i < 3; ++i) {
+                    for (int j = 0; j < 3; ++j)
+                        ATA2[i][j] += A[i] * A[j];
+                    ATy2[i] += A[i] * y_assigned;
+                }
+            }
+            double newP[3] = {0.0, 0.0, 0.0};
+            if (!Solve3(ATA2, ATy2, newP)) break;
+            bestP[0] = newP[0]; bestP[1] = newP[1]; bestP[2] = newP[2];
+            std::cout << "[ReconstructMDT] Iter L/R pass " << (iter+1)
+                      << ": flipped=" << nFlipped << " newSlope=" << bestP[1]
+                      << " newQP=" << bestP[2] << "\n";
+        }
+
+        // Phase 3.7: Hough vote-count rescue for events stuck in a local L/R minimum.
+        // Enumerate all triplets (i,j,k) from at least 2 different stations.  For each
+        // of 8 side combos, solve the 3×3 system for (y0, slope, q/p) exactly.  Score
+        // by VOTE COUNT — how many of the N hits agree with the candidate track within a
+        // tolerance window — rather than by chi².  Vote counting is what the ATLAS Legendre
+        // sinogram does and is key: 3 contaminated hits forming a perfect fake line get
+        // only 3 votes, while the true 12-hit muon track gets ≥10 votes and always wins.
+        // Only triggered when the iterative fit (Phase 3.5) is still stuck (chi2 > 1000).
+        {
+            // Current analytic chi² with Phase-3.5 L/R
+            const double sigma2 = smear_mm * smear_mm;
+            double chi2Current = 0.0;
+            for (int h = 0; h < N; ++h) {
+                const double y_a  = resolvedEventHits[h].wy_l + resolvedEventHits[h].assignedSide * resolvedEventHits[h].r;
+                const double zRel = resolvedEventHits[h].wz_l - z0Local;
+                const double res  = y_a - (bestP[0] + bestP[1]*zRel + bestP[2]*kernelY[h]);
+                chi2Current += res*res / sigma2;
+            }
+
+            if (chi2Current > 1000.0) {
+                // 5σ tolerance: real hits on the correct side will always be inside;
+                // hits on the wrong side (offset by ~2r ≈ 14-29mm) will be outside.
+                const double tol = 5.0 * smear_mm;
+
+                struct HC { double yp, ym, zRel, kY; int sta; };
+                std::vector<HC> hc(N);
+                for (int h = 0; h < N; ++h) {
+                    const auto& hit = resolvedEventHits[h];
+                    hc[h].yp   = hit.wy_l + hit.r;
+                    hc[h].ym   = hit.wy_l - hit.r;
+                    hc[h].zRel = hit.wz_l - z0Local;
+                    hc[h].kY   = kernelY[h];
+                    hc[h].sta  = hit.sta;
+                }
+
+                int bestVotes = 0;
+                double bestChi2AtPeak = 1e18;
+                std::vector<int> bestSidesHough(N);
+                for (int h = 0; h < N; ++h)
+                    bestSidesHough[h] = resolvedEventHits[h].assignedSide;
+
+                for (int i = 0; i < N-2; ++i) {
+                    for (int j = i+1; j < N-1; ++j) {
+                        for (int k = j+1; k < N; ++k) {
+                            if (hc[i].sta == hc[j].sta && hc[i].sta == hc[k].sta) continue;
+
+                            for (int combo = 0; combo < 8; ++combo) {
+                                const double yi = (combo & 1) ? hc[i].yp : hc[i].ym;
+                                const double yj = (combo & 2) ? hc[j].yp : hc[j].ym;
+                                const double yk = (combo & 4) ? hc[k].yp : hc[k].ym;
+
+                                double Amat[3][3] = {
+                                    {1.0, hc[i].zRel, hc[i].kY},
+                                    {1.0, hc[j].zRel, hc[j].kY},
+                                    {1.0, hc[k].zRel, hc[k].kY}
+                                };
+                                double rhs[3] = {yi, yj, yk};
+                                double sol[3] = {};
+                                if (!Solve3(Amat, rhs, sol)) continue;
+
+                                const double y0_c = sol[0], sl_c = sol[1], qp_c = sol[2];
+
+                                // Physics cuts: reject unphysical FASER muon candidates
+                                if (std::fabs(sl_c) > 0.15) continue;
+                                if (std::fabs(qp_c) > 1.0)  continue;
+
+                                // Score by VOTE COUNT: count hits within tolerance of the
+                                // candidate track using each hit's best (closest) side.
+                                int votes = 0;
+                                double chi2AtPeak = 0.0;
+                                std::vector<int> sides(N);
+                                for (int h = 0; h < N; ++h) {
+                                    const double yPred = y0_c + sl_c*hc[h].zRel + qp_c*hc[h].kY;
+                                    const double rp = std::fabs(hc[h].yp - yPred);
+                                    const double rm = std::fabs(hc[h].ym - yPred);
+                                    sides[h] = (rp <= rm) ? 1 : -1;
+                                    const double minR = std::min(rp, rm);
+                                    if (minR < tol) ++votes;
+                                    chi2AtPeak += minR*minR / sigma2;
+                                }
+
+                                // Primary rank: most votes; secondary: lowest chi²
+                                if (votes > bestVotes ||
+                                    (votes == bestVotes && chi2AtPeak < bestChi2AtPeak)) {
+                                    bestVotes      = votes;
+                                    bestChi2AtPeak = chi2AtPeak;
+                                    bestSidesHough = sides;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Apply only if Hough found strong consensus (≥ N-2 votes) and
+                // the candidate changes something
+                if (bestVotes >= N - 2) {
+                    int nFlippedH = 0;
+                    for (int h = 0; h < N; ++h) {
+                        if (bestSidesHough[h] != resolvedEventHits[h].assignedSide) {
+                            resolvedEventHits[h].assignedSide = bestSidesHough[h];
+                            ++nFlippedH;
+                        }
+                    }
+                    if (nFlippedH > 0) {
+                        double ATA4[3][3]={}, ATy4[3]={};
+                        for (int h = 0; h < N; ++h) {
+                            const auto& hit = resolvedEventHits[h];
+                            const double y_a = hit.wy_l + hit.assignedSide * hit.r;
+                            const double zRel = hit.wz_l - z0Local;
+                            double A[3] = {1.0, zRel, kernelY[h]};
+                            for (int ii=0;ii<3;++ii){
+                                for (int jj=0;jj<3;++jj) ATA4[ii][jj]+=A[ii]*A[jj];
+                                ATy4[ii]+=A[ii]*y_a;
+                            }
+                        }
+                        double newP[3]={};
+                        if (Solve3(ATA4, ATy4, newP)){
+                            bestP[0]=newP[0]; bestP[1]=newP[1]; bestP[2]=newP[2];
+                        }
+                        std::cout << "[ReconstructMDT] Hough-vote: chi2Current=" << chi2Current
+                                  << " votes=" << bestVotes << "/" << N
+                                  << " flipped=" << nFlippedH
+                                  << " slope=" << bestP[1] << " qp=" << bestP[2] << "\n";
+                    }
+                }
+            }
+        }
+
         const double pAnalytic = (std::fabs(bestP[2]) > 1.0e-12)
                                ? std::fabs(1.0 / bestP[2])
                                : -999.0;
@@ -4415,16 +4545,193 @@ void TPORecoEvent::ReconstructMDT()
         // run GenFit track fitting
         // verbose = 1 for debug prints, 0 for quiet
         // GenFit expects momentum in GeV/c
-	// Only reject sub-1-GeV pAnalytic values as degenerate (sagitta floor artifact).
+        // Only reject sub-1-GeV pAnalytic values as degenerate (sagitta floor artifact).
         // Values 1-1000 GeV are valid seeds even if they may be imprecise.
         const double seedPForGenFit =
             (pAnalytic >= 1.0 && pAnalytic <= 1000.0 && std::isfinite(pAnalytic))
             ? pAnalytic
             : seedMomentumGeV;
 
- 
         trk.fpAnalytic = pAnalytic;
-        const bool ok = trk.GenFitMDTFit(meas, mdt->fPDG, seedPForGenFit, 1 /*verbose*/);
+        // Use the analytic charge sign for the GenFit PDG so that the
+        // RKTrackRep charge matches the bending direction implied by the L/R
+        // assignment.  When the per-station L/R picks the mirror image, the
+        // analytic fit gives the opposite charge sign; using it keeps GenFit's
+        // propagation consistent with the measurements.
+        const int pdgForFit = (qAnalytic > 0.0) ? -13 : 13;  // +1 → mu+, -1 → mu-
+        if (pdgForFit != mdt->fPDG) {
+            std::cout << "[ReconstructMDT] Charge flip: analytic q=" << qAnalytic
+                      << " differs from truth PDG=" << mdt->fPDG
+                      << " → using PDG=" << pdgForFit << " for GenFit\n";
+        }
+        bool ok = trk.GenFitMDTFit(meas, pdgForFit, seedPForGenFit, 1 /*verbose*/, bestP[1]);
+
+        // Outlier-rejection rescue: when the full-hit fit fails AND we have
+        // enough hits, iteratively remove the hit(s) most inconsistent with the
+        // analytic track (bestP) and retry GenFit.  Contaminated hits from a
+        // secondary particle have large analytic residuals even when the L/R is
+        // correct for the muon, so they float to the top of the sorted list.
+        // We try removing 1, 2, 3 hits in sequence; stop as soon as a fit
+        // succeeds or when fewer than 6 hits remain (NDF < 1).
+        if (!ok && N >= 9) {
+            // Sort hit indices by descending |analytic residual| (in σ units).
+            const double sig2Out = smear_mm * smear_mm;
+            std::vector<std::pair<double,int>> resVec(N);
+            for (int h = 0; h < N; ++h) {
+                const auto& rh   = resolvedEventHits[h];
+                const double y_a = rh.wy_l + rh.assignedSide * rh.r;
+                const double zRel = rh.wz_l - z0Local;
+                const double res  = y_a - (bestP[0] + bestP[1]*zRel + bestP[2]*kernelY[h]);
+                resVec[h]         = {res*res / sig2Out, h};
+            }
+            std::sort(resVec.begin(), resVec.end(),
+                      [](const auto& a, const auto& b){ return a.first > b.first; });
+
+            const int maxRemove = std::min(6, N - 6); // keep at least 6 hits (NDF≥1)
+            for (int nRem = 1; nRem <= maxRemove && !ok; ++nRem) {
+                // Build cleaned meas list, then re-fit analytic bestP on the survivors
+                // to get a better seed slope and seed momentum for GenFit.
+                std::vector<bool> excl(N, false);
+                for (int i = 0; i < nRem; ++i) excl[resVec[i].second] = true;
+
+                std::vector<MDTMeas> measClean;
+                measClean.reserve(N - nRem);
+                for (int h = 0; h < N; ++h)
+                    if (!excl[h]) measClean.push_back(meas[h]);
+
+                // Re-fit analytic model on survivors to get uncontaminated slope/qp.
+                double ATA_c[3][3]={}, ATy_c[3]={}, Pc[3]={};
+                for (int h = 0; h < N; ++h) {
+                    if (excl[h]) continue;
+                    const auto& rh   = resolvedEventHits[h];
+                    const double y_a = rh.wy_l + rh.assignedSide * rh.r;
+                    const double zRel = rh.wz_l - z0Local;
+                    const double A[3] = {1.0, zRel, kernelY[h]};
+                    for (int ii=0;ii<3;++ii){ for (int jj=0;jj<3;++jj) ATA_c[ii][jj]+=A[ii]*A[jj]; ATy_c[ii]+=A[ii]*y_a; }
+                }
+                const bool solvedClean = Solve3(ATA_c, ATy_c, Pc);
+                const double slopeClean = solvedClean ? Pc[1] : bestP[1];
+                const double qpClean    = solvedClean ? Pc[2] : bestP[2];
+                const double pClean     = (std::fabs(qpClean) > 1e-12 && std::fabs(qpClean) < 1.0)
+                                           ? std::fabs(1.0 / qpClean) : seedPForGenFit;
+
+                TMuTrack trkC;
+                trkC.ftrackID  = tid;
+                trkC.fPDG      = mdt->fPDG;
+                trkC.fpAnalytic = (std::fabs(qpClean) > 1e-12) ? std::fabs(1.0/qpClean) : pAnalytic;
+                const bool okC = trkC.GenFitMDTFit(measClean, pdgForFit, pClean, 1, slopeClean);
+                if (okC) {
+                    trk = trkC;
+                    ok  = true;
+                    std::cout << "[ReconstructMDT] OutlierRescue nRemoved=" << nRem
+                              << " p=" << trk.fp << " GeV/c  q=" << trk.fcharge
+                              << " chi2=" << trk.fchi2 << " ndf=" << trk.fnDoF << "\n";
+                }
+            }
+        }
+
+        // ── Two-track rescue ──────────────────────────────────────────────────
+        // If any hits are inconsistent with the primary analytic track (bestP),
+        // they may belong to a second independent muon (e.g. from tau decay, a
+        // cosmic, or a second neutrino interaction).  Classify hits by their
+        // residual from bestP, then attempt independent fits on each group.
+        //
+        // Track A (consistent hits): used as a fallback when single-track fits
+        //   all failed AND the outlier rescue was limited (nIncons > maxRemove).
+        // Track B (inconsistent hits): always attempted when ≥ 6 hits are
+        //   inconsistent; if successful it is added to fMuTracks as a second track.
+        TMuTrack trkB;
+        if (N >= 10) {
+            const double tol2t = 5.0 * smear_mm;
+            std::vector<int> idxA, idxB;
+            for (int h = 0; h < N; ++h) {
+                const auto& rh   = resolvedEventHits[h];
+                const double y_a = rh.wy_l + rh.assignedSide * rh.r;
+                const double zRel = rh.wz_l - z0Local;
+                const double res  = std::fabs(y_a - (bestP[0] + bestP[1]*zRel + bestP[2]*kernelY[h]));
+                (res < tol2t ? idxA : idxB).push_back(h);
+            }
+            const int nA = static_cast<int>(idxA.size());
+            const int nB = static_cast<int>(idxB.size());
+
+            if (nA >= 5 && nB >= 5)
+                std::cout << "[ReconstructMDT] TwoTrack: " << nA
+                          << " consistent + " << nB << " inconsistent hits\n";
+
+            // ── Track A: primary-consistent hits, rescue if still failing ──────
+            // Only needed when outlier rescue was blocked (nIncons > maxRemove=6)
+            if (!ok && nA >= 6 && nB > 6) {
+                double ATA_A[3][3]={}, ATy_A[3]={}, PA[3]={};
+                for (int hi : idxA) {
+                    const auto& rh   = resolvedEventHits[hi];
+                    const double y_a = rh.wy_l + rh.assignedSide * rh.r;
+                    const double zRel = rh.wz_l - z0Local;
+                    const double A[3] = {1.0, zRel, kernelY[hi]};
+                    for (int ii=0;ii<3;++ii){ for (int jj=0;jj<3;++jj) ATA_A[ii][jj]+=A[ii]*A[jj]; ATy_A[ii]+=A[ii]*y_a; }
+                }
+                const bool solA   = Solve3(ATA_A, ATy_A, PA);
+                const double slA  = solA ? PA[1] : bestP[1];
+                const double qpA  = solA ? PA[2] : bestP[2];
+                const double pA   = (std::fabs(qpA) > 1e-12 && std::fabs(qpA) < 1.0)
+                                    ? std::fabs(1.0/qpA) : seedPForGenFit;
+                const int pdgA    = (qpA > 0.0) ? -13 : 13;
+
+                std::vector<MDTMeas> measA;
+                for (int hi : idxA) measA.push_back(meas[hi]);
+
+                TMuTrack trkA;
+                trkA.ftrackID  = tid;
+                trkA.fPDG      = mdt->fPDG;
+                trkA.fpAnalytic = std::fabs(qpA) > 1e-12 ? std::fabs(1.0/qpA) : pAnalytic;
+                if (trkA.GenFitMDTFit(measA, pdgA, pA, 1, slA)) {
+                    trk = trkA;
+                    ok  = true;
+                    std::cout << "[ReconstructMDT] TwoTrack-A: p=" << trk.fp
+                              << " q=" << trk.fcharge << " ndf=" << trk.fnDoF << "\n";
+                }
+            }
+
+            // ── Track B: inconsistent hits, fit as independent second track ───
+            if (nB >= 6) {
+                // Analytic seed from wire centers (side-neutral): avoids primary
+                // L/R bias which is wrong for the B-track trajectory.
+                double ATA_B[3][3]={}, ATy_B[3]={}, PB[3]={};
+                for (int hi : idxB) {
+                    const double y_b  = resolvedEventHits[hi].wy_l; // wire center
+                    const double zRel = resolvedEventHits[hi].wz_l - z0Local;
+                    const double A[3] = {1.0, zRel, kernelY[hi]};
+                    for (int ii=0;ii<3;++ii){ for (int jj=0;jj<3;++jj) ATA_B[ii][jj]+=A[ii]*A[jj]; ATy_B[ii]+=A[ii]*y_b; }
+                }
+                const bool solB  = Solve3(ATA_B, ATy_B, PB);
+                const double slB = solB ? PB[1] : 0.0;
+                const double qpB = solB ? PB[2] : 0.0;
+                const double pB  = (std::fabs(qpB) > 1e-12 && std::fabs(qpB) < 1.0)
+                                   ? std::fabs(1.0/qpB) : seedMomentumGeV;
+                const int pdgB   = (qpB > 0.0) ? -13 : 13;
+
+                // Pass measurements with side=+1 as neutral initial guess.
+                // GenFitMDTFit's internal retry (L/R re-assignment from the partial
+                // Kalman state of the B trajectory) will correct the side.
+                std::vector<MDTMeas> measB;
+                for (int hi : idxB) {
+                    MDTMeas mb    = meas[hi];
+                    mb.side       = 1;
+                    mb.y_mm       = mb.wireY_mm + mb.r_meas_mm; // side=+1, global mm
+                    measB.push_back(mb);
+                }
+
+                trkB.ftrackID  = tid;
+                trkB.fPDG      = mdt->fPDG;
+                trkB.fpAnalytic = std::fabs(qpB) > 1e-12 ? std::fabs(1.0/qpB) : -999.0;
+                if (trkB.GenFitMDTFit(measB, pdgB, pB, 1, slB)) {
+                    trkB.ffit_ok = true;
+                    std::cout << "[ReconstructMDT] TwoTrack-B (2nd track): p=" << trkB.fp
+                              << " q=" << trkB.fcharge << " ndf=" << trkB.fnDoF << "\n";
+                }
+            }
+        }
+        // ── end two-track rescue ──────────────────────────────────────────────
+
         trk.ffit_ok = ok;
         if (ok) {
             std::cout << "[ReconstructMDT] GenFit Kalman SUCCESS:"
@@ -4439,6 +4746,7 @@ void TPORecoEvent::ReconstructMDT()
                       << " pAnalytic=" << pAnalytic << " GeV/c" << std::endl;
         }
         fMuTracks.push_back(trk);
+        if (trkB.ffit_ok) fMuTracks.push_back(trkB);
     }
 }
 /////////////////////////////////////


### PR DESCRIPTION
Implement end-to-end MDT muon momentum reconstruction in TPORecoEvent::ReconstructMDT()
with a multi-stage fitting pipeline....

## Results on 5210-event sample (Batch-TPORecevent_6000_0_5210.root coming from 3DCAL nu interactions)
- 1509 events with MDT muon hits 
- 686 fit successes (45.5%)
- 179 NDF=7 tracks (full 12-hit, best quality)
- Outlier rescue: ~387 activations; Two-track B: ~40 second-muon tracks found
- 823 events remain failed (partial station coverage or unfixable contamination)