### PR TITLE
Modify muon reco in MDT and improve in detector response implementation

### DIFF
--- a/Batch/BatchReco_DetResp.cc
+++ b/Batch/BatchReco_DetResp.cc
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <iostream>
 #include <fstream>
+#include <map>
 #include <sys/resource.h>
 #include <unistd.h>
 #include <chrono>
@@ -189,6 +190,19 @@ int main(int argc, char** argv) {
     TH1D h_charm_Enuall = TH1D("h_charm_Enuall", "Neutrino energy", 50, 0, 4000.0);
     TH1D h_charm_Enucharmed = TH1D("h_charm_Enucharmed", "Neutrino energy", 50, 0, 4000.0);
     
+    // FASERCal fiber channel PE distributions (summary across all events)
+    TH1D h_fiber_X_PE_all = TH1D("h_fiber_X_PE_all", "X-fibers: PE per channel (all events);PE;Channels", 200, 0., 2000.);
+    TH1D h_fiber_Y_PE_all = TH1D("h_fiber_Y_PE_all", "Y-fibers: PE per channel (all events);PE;Channels", 200, 0., 2000.);
+    TH1D h_fiber_Z_PE_all = TH1D("h_fiber_Z_PE_all", "Z-fibers: PE per channel (all events);PE;Channels", 200, 0., 2000.);
+    TH2D h_fiber_X_map_sum = TH2D("h_fiber_X_map_sum", "X-fibers: PE map (all events);Y;Z;PE", 48, 0, 48, 48, 0, 48);
+    TH2D h_fiber_Y_map_sum = TH2D("h_fiber_Y_map_sum", "Y-fibers: PE map (all events);X;Z;PE", 11, 0, 11, 48, 0, 48);
+    TH2D h_fiber_Z_map_sum = TH2D("h_fiber_Z_map_sum", "Z-fibers: PE map (all events);X;Y;PE", 11, 0, 11, 48, 0, 48);
+    
+    // FASERCal fiber channel nVoxelsHit distributions (fiber sharing)
+    TH1D h_fiber_X_nHits_all = TH1D("h_fiber_X_nHits_all", "X-fibers: Voxels hit per channel (all events);N voxels;Channels", 111, 0, 111);
+    TH1D h_fiber_Y_nHits_all = TH1D("h_fiber_Y_nHits_all", "Y-fibers: Voxels hit per channel (all events);N voxels;Channels", 48, 0, 48);
+    TH1D h_fiber_Z_nHits_all = TH1D("h_fiber_Z_nHits_all", "Z-fibers: Voxels hit per channel (all events);N voxels;Channels", 48, 0, 48);
+    
     // TParticleGun
     TParticleGun fTParticleGun;
     TTree *m_particlegun_Tree = new TTree("ParticleGun","ParticleGun");
@@ -278,16 +292,42 @@ int main(int argc, char** argv) {
         /////
 #endif
         TPORecoEvent* fPORecoEvent = new TPORecoEvent(fTcalEvent, fTcalEvent->fTPOEvent);
-        fPORecoEvent -> verbose = 0;   // 0: no output, 1: some output, 2: more output, 3: full output;
-        if(!dump_event_cout) fPORecoEvent -> verbose = 0;
+        fPORecoEvent -> verbose = 2;   // 0: no output, 1: some output, 2: more output, 3: full output;
+        if(!dump_event_cout) fPORecoEvent -> verbose = 1;  // Enable for duplicate detection debugging
         fPORecoEvent -> multiThread = multiThread_option;
         fPORecoEvent -> ReconstructTruth();
+        
+        // Add detector response (uses defaults: see TPORecoEvent.hh, or customize here)
+        fPORecoEvent->ApplyFaserCalDetectorResponse();
+        
+        // Fill summary fiber channel histograms
+        for (const auto& ch : fPORecoEvent->faserCalFiberChannelsX) {
+            h_fiber_X_PE_all.Fill(ch.totalPE);
+            h_fiber_X_map_sum.Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+            h_fiber_X_nHits_all.Fill(ch.nVoxelsHit);
+        }
+        for (const auto& ch : fPORecoEvent->faserCalFiberChannelsY) {
+            h_fiber_Y_PE_all.Fill(ch.totalPE);
+            h_fiber_Y_map_sum.Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+            h_fiber_Y_nHits_all.Fill(ch.nVoxelsHit);
+        }
+        for (const auto& ch : fPORecoEvent->faserCalFiberChannelsZ) {
+            h_fiber_Z_PE_all.Fill(ch.totalPE);
+            h_fiber_Z_map_sum.Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+            h_fiber_Z_nHits_all.Fill(ch.nVoxelsHit);
+        }
+        
+        // Dump fiber channel PE distributions for early events
+        if(dump_event_cout) {
+            fPORecoEvent->DumpFaserCalFiberChannels(10, true);  // Show top 10 channels sorted by PE
+        }
+        //
+        //fPORecoEvent -> verbose = 0;   // 0: no output, 1: some output, 2: more output, 3: full output;
         fPORecoEvent -> Reconstruct2DViewsPS();
         fPORecoEvent -> ReconstructClusters(0);
         fPORecoEvent -> Reconstruct3DPS_2();
         fPORecoEvent -> ReconstructRearCals();
-        //fPORecoEvent -> ReconstructMuonSpectrometer();
-        fPORecoEvent -> ReconstructMDT();
+        fPORecoEvent -> ReconstructMuonSpectrometer();
         #if 0
         // poor's man fit of beta scan
         float betas[] = {3.5, 4.0, 4.5, 5.0, 5.5, 6.0};
@@ -465,20 +505,6 @@ int main(int argc, char** argv) {
             fTMuonSpectrometer.features.pval[i] = aMuTrack->fpval;
             fTMuonSpectrometer.features.fpErr[i] = aMuTrack->fpErr;
             fTMuonSpectrometer.features.fipErr[i] = aMuTrack->fipErr;
-            fTMuonSpectrometer.features.fit_ok[i] = aMuTrack->ffit_ok ? 1 : 0;
-            fTMuonSpectrometer.features.p_analytic[i] = aMuTrack->fpAnalytic;
-            // Match to MDTTrack by trackID to get truth momentum at first MDT hit.
-            // MDTTrack::mom is stored in MeV/c (Geant4 units) → divide by 1000 for GeV/c.
-            fTMuonSpectrometer.features.p_truth[i] = -999.0f;
-            fTMuonSpectrometer.features.charge_truth[i] = -999.0f;
-            for (const auto* mdtT : fTcalEvent->fMDTTracks) {
-                if (mdtT->ftrackID == aMuTrack->ftrackID && !mdtT->mom.empty()) {
-                    fTMuonSpectrometer.features.p_truth[i] = (float)(mdtT->mom[0].R() / 1000.0);
-                    // PDG 13 = mu- (charge -1), PDG -13 = mu+ (charge +1)
-                    fTMuonSpectrometer.features.charge_truth[i] = (mdtT->fPDG > 0) ? -1.0f : 1.0f;
-                    break;
-                }
-            }
         }
         fTMuonSpectrometer.Fill_Sel_Tree(m_muonspect_Tree);
 

--- a/Batch/Makefile
+++ b/Batch/Makefile
@@ -1,10 +1,12 @@
 EXE = batchreco.exe
 EXE2 = dumphits.exe
+EXE3 = batchreco_detresp.exe
 
 include ../Makefile.common
 
 SRC = BatchReco.cc
 SRC2 = DumpHits.cc
+SRC3 = BatchReco_DetResp.cc
 
 SRCCORE = $(wildcard $(COREUTILSDIR)/*.cc)
 OBJCORE := $(SRCCORE:.cc=.o)
@@ -21,6 +23,12 @@ OBJ2 := $(OBJ2:.cxx=.o)
 OBJ2 := $(OBJ2:.cc=.o)
 OBJ2 += dict.o
 
+SRC3 += $(SRCCORE)
+OBJ3 = $(SRC3:.C=.o)
+OBJ3 := $(OBJ3:.cxx=.o)
+OBJ3 := $(OBJ3:.cc=.o)
+OBJ3 += dict.o
+
 INCS = $(wildcard *.h)
 INCS += $(wildcard *.hh)
 INCS += $(wildcard $(COREUTILSDIR)/*.hh)
@@ -29,7 +37,7 @@ LINKLIB := -L$(ROOTSYS)/lib `root-config --glibs` -lEG -lGeom $(GENFITLIBS)
 # ROOTCFLAGS += -fsanitize=address 
 ROOTCFLAGS += -O3
 
-all : $(EXE) $(EXE2)
+all : $(EXE) $(EXE2) $(EXE3)
 
 dict.cxx : $(INCS) $(SRC)
 	rootcling -f dict.cxx -c LinkDef.h -I$(COREUTILSDIR) -I$(GENFITINCDIR)
@@ -41,6 +49,10 @@ $(EXE) : $(OBJ) Makefile
 $(EXE2) : $(OBJ2) Makefile
 	g++ $(ROOTCFLAGS) $(OBJ2) $(LINKLIB) -o $@
 
+$(EXE3) : $(OBJ3) Makefile
+	g++ $(ROOTCFLAGS) $(OBJ3) $(LINKLIB) -o $@
+	g++ -shared -o libTPORec.so dict.o $(OBJCORE) $(LINKLIB)
+
 # Compile source files to object files
 %.o: %.C $(INCS)
 	$(CXX) $(ROOTCFLAGS) -c $< -o $@
@@ -51,7 +63,7 @@ $(EXE2) : $(OBJ2) Makefile
 
 # Clean target
 clean:
-	rm -f $(OBJ) $(EXE) $(EXE2) $(OBJ2) dict.cxx dict_rdict.pcm libTPORec.so
+	rm -f $(OBJ) $(EXE) $(EXE2) $(OBJ2) $(EXE3) $(OBJ3) dict.cxx dict_rdict.pcm libTPORec.so
 
 .PHONY : all clean
 

--- a/Batch/check_mdt_reco.C
+++ b/Batch/check_mdt_reco.C
@@ -1,0 +1,283 @@
+// check_mdt_reco.C
+// Usage:  root -l -b -q 'check_mdt_reco.C("Batch-TPORecevent_6000_0_5210.root")'
+//
+// Prints MDT reconstruction statistics and plots truth vs reco momentum resolution.
+// Requires the p_truth branch (added after Jul 2026 rebuild).
+
+void check_mdt_reco(const char* fname = "Batch-TPORecevent_6000_0_5210.root")
+{
+    TFile* f = TFile::Open(fname);
+    if (!f || f->IsZombie()) { std::cerr << "Cannot open " << fname << "\n"; return; }
+
+    TTree* t = (TTree*)f->Get("MuonSpectrometer");
+    if (!t) { std::cerr << "TTree 'MuonSpectrometer' not found\n"; return; }
+
+    const bool hasTruth = (t->GetBranch("p_truth") != nullptr);
+    if (!hasTruth) printf("[WARNING] p_truth branch not found — truth resolution plots disabled.\n");
+
+    const Long64_t nEntries = t->GetEntries();
+
+    // --- branch variables ---
+    const int MAXTRK = 10;
+    int   ntracks = 0;
+    int   fit_ok [MAXTRK] = {};
+    int   nDoF   [MAXTRK] = {};
+    float p      [MAXTRK] = {};
+    float p_analytic[MAXTRK] = {};
+    float p_truth   [MAXTRK] = {};
+    float chi2   [MAXTRK] = {};
+    float charge [MAXTRK] = {};
+    float fpErr  [MAXTRK] = {};
+
+    t->SetBranchAddress("ntracks",     &ntracks);
+    t->SetBranchAddress("fit_ok",       fit_ok);
+    t->SetBranchAddress("nDoF",         nDoF);
+    t->SetBranchAddress("p",            p);
+    t->SetBranchAddress("p_analytic",   p_analytic);
+    t->SetBranchAddress("chi2",         chi2);
+    t->SetBranchAddress("charge",       charge);
+    t->SetBranchAddress("fpErr",        fpErr);
+    if (hasTruth) t->SetBranchAddress("p_truth", p_truth);
+
+    // --- counters ---
+    int nEventsTotal     = 0;
+    int nEventsNoTrack   = 0;
+    int nEventsAttempted = 0;
+    int nFitFailed       = 0;
+    int nSecondTrack     = 0;
+    int nNDF0            = 0;
+
+    std::map<int,int> ndfHist;
+
+    // momentum data vectors (fit_ok, physics range)
+    // "all"  = all fit_ok, NDF>0 tracks in physics range
+    // "good" = additionally require chi2/NDF < chi2Cut (well-reconstructed)
+    const double chi2Cut = 10.0;
+    std::vector<double> pFit, pAna, pTru;           // all
+    std::vector<double> pFitG, pAnaG, pTruG;        // good chi2
+    std::vector<double> dp_over_p_genfit,   dp_over_p_genfit_g;
+    std::vector<double> dp_over_p_analytic, dp_over_p_analytic_g;
+    std::vector<double> dinvp_genfit,       dinvp_genfit_g;
+    std::vector<double> dinvp_analytic,     dinvp_analytic_g;
+    std::vector<double> chi2ndfVec;
+
+    const float PMAX = 1e4f; // upper sanity cut
+
+    for (Long64_t ev = 0; ev < nEntries; ++ev) {
+        t->GetEntry(ev);
+        ++nEventsTotal;
+
+        if (ntracks == 0) { ++nEventsNoTrack; continue; }
+        ++nEventsAttempted;
+        if (ntracks >= 2) ++nSecondTrack;
+
+        bool anyOk = false;
+        for (int tr = 0; tr < std::min(ntracks, MAXTRK); ++tr) {
+            if (!fit_ok[tr]) continue;
+            anyOk = true;
+
+            int ndf = nDoF[tr];
+            ndfHist[ndf]++;
+            if (ndf == 0) { ++nNDF0; continue; }
+
+            const double cndf = (ndf > 0) ? chi2[tr] / ndf : 1e9;
+            if (cndf < 1e6) chi2ndfVec.push_back(cndf);
+            const bool goodChi2 = (cndf < chi2Cut);
+
+            const float pf = p[tr];
+            const float pa = p_analytic[tr];
+            const float pt = hasTruth ? p_truth[tr] : -999.f;
+
+            // GenFit vs truth
+            if (hasTruth
+             && std::isfinite(pf) && pf > 0 && pf < PMAX
+             && std::isfinite(pt) && pt > 0 && pt < PMAX) {
+                pFit.push_back(pf);
+                pTru.push_back(pt);
+                dp_over_p_genfit.push_back((pf - pt) / pt);
+                dinvp_genfit.push_back(1.0/pf - 1.0/pt);
+                if (goodChi2) {
+                    pFitG.push_back(pf); pTruG.push_back(pt);
+                    dp_over_p_genfit_g.push_back((pf - pt) / pt);
+                    dinvp_genfit_g.push_back(1.0/pf - 1.0/pt);
+                }
+            }
+            // Analytic vs truth
+            if (hasTruth
+             && std::isfinite(pa) && pa > 0 && pa < PMAX
+             && std::isfinite(pt) && pt > 0 && pt < PMAX) {
+                pAna.push_back(pa);
+                dp_over_p_analytic.push_back((pa - pt) / pt);
+                dinvp_analytic.push_back(1.0/pa - 1.0/pt);
+                if (goodChi2) {
+                    pAnaG.push_back(pa);
+                    dp_over_p_analytic_g.push_back((pa - pt) / pt);
+                    dinvp_analytic_g.push_back(1.0/pa - 1.0/pt);
+                }
+            }
+        }
+        if (!anyOk) ++nFitFailed;
+    }
+
+    // compute mean and RMS of a vector
+    auto vecMean = [](const std::vector<double>& v) -> double {
+        if (v.empty()) return 0;
+        double s = 0; for (double x : v) s += x; return s / v.size();
+    };
+    auto vecRMS = [&vecMean](const std::vector<double>& v) -> double {
+        if (v.empty()) return 0;
+        double mu = vecMean(v), s = 0;
+        for (double x : v) s += (x-mu)*(x-mu);
+        return std::sqrt(s / v.size());
+    };
+
+    double mu_dpp_gf      = vecMean(dp_over_p_genfit),    sig_dpp_gf      = vecRMS(dp_over_p_genfit);
+    double mu_dpp_ana     = vecMean(dp_over_p_analytic),  sig_dpp_ana     = vecRMS(dp_over_p_analytic);
+    double mu_dinvp_gf    = vecMean(dinvp_genfit),        sig_dinvp_gf    = vecRMS(dinvp_genfit);
+    double mu_dinvp_ana   = vecMean(dinvp_analytic),      sig_dinvp_ana   = vecRMS(dinvp_analytic);
+    double mu_dpp_gf_g    = vecMean(dp_over_p_genfit_g),  sig_dpp_gf_g    = vecRMS(dp_over_p_genfit_g);
+    double mu_dpp_ana_g   = vecMean(dp_over_p_analytic_g),sig_dpp_ana_g   = vecRMS(dp_over_p_analytic_g);
+    double mu_dinvp_gf_g  = vecMean(dinvp_genfit_g),      sig_dinvp_gf_g  = vecRMS(dinvp_genfit_g);
+    double mu_dinvp_ana_g = vecMean(dinvp_analytic_g),    sig_dinvp_ana_g = vecRMS(dinvp_analytic_g);
+    double mu_chi2        = vecMean(chi2ndfVec);
+
+    // --- Print summary ---
+    printf("\n========================================\n");
+    printf("  MDT Reco Statistics: %s\n", fname);
+    printf("========================================\n");
+    printf("  Total events                  : %d\n", nEventsTotal);
+    printf("  Events with no MDT track      : %d\n", nEventsNoTrack);
+    printf("  Events with MDT track(s)      : %d  (%.1f%%)\n",
+           nEventsAttempted, 100.0*nEventsAttempted/nEventsTotal);
+    printf("  Events with 2nd track (B)     : %d\n", nSecondTrack);
+    printf("\n");
+    printf("  Fit SUCCESS events            : %d  (%.1f%% of attempted)\n",
+           nEventsAttempted - nFitFailed,
+           nEventsAttempted ? 100.0*(nEventsAttempted-nFitFailed)/nEventsAttempted : 0.0);
+    printf("  Fit FAILED  events            : %d\n", nFitFailed);
+    printf("\n");
+    printf("  NDF distribution (fit_ok tracks):\n");
+    for (auto& kv : ndfHist)
+        printf("    NDF = %3d : %d tracks\n", kv.first, kv.second);
+    printf("  fit_ok tracks with NDF=0      : %d  (DAF garbage)\n", nNDF0);
+    printf("  Mean chi2/NDF (NDF>0)         : %.2f\n", mu_chi2);
+    printf("\n");
+    if (hasTruth) {
+        printf("  --- GenFit vs truth  ALL (N=%zu) ---\n", pFit.size());
+        printf("  (p_fit-p_truth)/p_truth    : mean=%+.3f  RMS=%.3f\n", mu_dpp_gf, sig_dpp_gf);
+        printf("  1/p_fit-1/p_truth [1/GeV]  : mean=%+.3e  RMS=%.3e\n", mu_dinvp_gf, sig_dinvp_gf);
+        printf("  --- GenFit vs truth  chi2/NDF<%.0f (N=%zu) ---\n", chi2Cut, pFitG.size());
+        printf("  (p_fit-p_truth)/p_truth    : mean=%+.3f  RMS=%.3f\n", mu_dpp_gf_g, sig_dpp_gf_g);
+        printf("  1/p_fit-1/p_truth [1/GeV]  : mean=%+.3e  RMS=%.3e\n", mu_dinvp_gf_g, sig_dinvp_gf_g);
+        printf("\n");
+        printf("  --- Analytic vs truth  ALL (N=%zu) ---\n", pAna.size());
+        printf("  (p_ana-p_truth)/p_truth    : mean=%+.3f  RMS=%.3f\n", mu_dpp_ana, sig_dpp_ana);
+        printf("  1/p_ana-1/p_truth [1/GeV]  : mean=%+.3e  RMS=%.3e\n", mu_dinvp_ana, sig_dinvp_ana);
+        printf("  --- Analytic vs truth  chi2/NDF<%.0f (N=%zu) ---\n", chi2Cut, pAnaG.size());
+        printf("  (p_ana-p_truth)/p_truth    : mean=%+.3f  RMS=%.3f\n", mu_dpp_ana_g, sig_dpp_ana_g);
+        printf("  1/p_ana-1/p_truth [1/GeV]  : mean=%+.3e  RMS=%.3e\n", mu_dinvp_ana_g, sig_dinvp_ana_g);
+    }
+    printf("========================================\n\n");
+
+    // --- Histograms ---
+    TCanvas* c = new TCanvas("c_mdt","MDT Reco Check",1800,1000);
+    int ncols = hasTruth ? 4 : 3;
+    c->Divide(ncols, 2);
+    int pad = 1;
+
+    // 1) NDF
+    c->cd(pad++);
+    TH1D* hNDF = new TH1D("hNDF","NDF of fit_ok tracks;NDF;Tracks",25,-0.5,24.5);
+    for (auto& kv : ndfHist)
+        for (int i = 0; i < kv.second; ++i) hNDF->Fill(kv.first);
+    hNDF->Draw();
+
+    // 2) chi2/NDF
+    c->cd(pad++);
+    TH1D* hChi2 = new TH1D("hChi2","#chi^{2}/NDF (fit_ok, NDF>0);#chi^{2}/NDF;Tracks",60,0,60);
+    for (double v : chi2ndfVec) hChi2->Fill(v);
+    hChi2->Draw();
+
+    // 3) Fitted p spectrum — log x
+    c->cd(pad++);
+    gPad->SetLogx();
+    const int NBINS = 50;
+    double logBins[NBINS+1];
+    for (int i = 0; i <= NBINS; ++i) logBins[i] = std::pow(10.0, 0.0 + i * 4.0/NBINS); // 1..10000 GeV
+    TH1D* hP = new TH1D("hP","Fitted |p| (fit_ok, NDF>0);p [GeV/c];Tracks",NBINS,logBins);
+    for (double v : pFit) hP->Fill(v);
+    hP->Draw();
+
+    if (hasTruth) {
+        // 4) p_fit vs p_truth 2D — log-log
+        c->cd(pad++);
+        gPad->SetLogx(); gPad->SetLogy();
+        double logBins2[NBINS+1];
+        for (int i = 0; i <= NBINS; ++i) logBins2[i] = std::pow(10.0, 0.0 + i * 4.0/NBINS);
+        TH2D* h2P = new TH2D("h2P","p_{fit} vs p_{truth};p_{truth} [GeV/c];p_{fit} [GeV/c]",
+                              NBINS,logBins2, NBINS,logBins2);
+        for (size_t i = 0; i < pFit.size(); ++i) h2P->Fill(pTru[i], pFit[i]);
+        h2P->Draw("COLZ");
+        TLine* diag = new TLine(1,1,1e4,1e4);
+        diag->SetLineColor(kRed); diag->SetLineWidth(2); diag->Draw();
+
+        // 5) GenFit (p_fit-p_truth)/p_truth — all vs good chi2
+        c->cd(pad++);
+        TH1D* hDp  = new TH1D("hDp_gf_all","GenFit #Deltap/p (all);(p_{fit}-p_{truth})/p_{truth};Tracks",60,-3,3);
+        TH1D* hDpG = new TH1D("hDp_gf_good",Form("#chi^{2}/NDF<%.0f",chi2Cut),60,-3,3);
+        for (double v : dp_over_p_genfit)   hDp->Fill(v);
+        for (double v : dp_over_p_genfit_g) hDpG->Fill(v);
+        hDp->SetLineColor(kBlue-7);  hDp->Draw();
+        hDpG->SetLineColor(kBlue+2); hDpG->SetLineWidth(2); hDpG->Draw("SAME");
+        gPad->BuildLegend(0.55,0.7,0.98,0.92);
+
+        // 6) Analytic (p_ana-p_truth)/p_truth — all vs good chi2
+        c->cd(pad++);
+        TH1D* hDpA  = new TH1D("hDp_ana_all","Analytic #Deltap/p (all);(p_{ana}-p_{truth})/p_{truth};Tracks",60,-3,3);
+        TH1D* hDpAG = new TH1D("hDp_ana_good",Form("#chi^{2}/NDF<%.0f",chi2Cut),60,-3,3);
+        for (double v : dp_over_p_analytic)   hDpA->Fill(v);
+        for (double v : dp_over_p_analytic_g) hDpAG->Fill(v);
+        hDpA->SetLineColor(kGreen-7);  hDpA->Draw();
+        hDpAG->SetLineColor(kGreen+3); hDpAG->SetLineWidth(2); hDpAG->Draw("SAME");
+        gPad->BuildLegend(0.55,0.7,0.98,0.92);
+
+        // 7) GenFit 1/p curvature resolution — all vs good chi2
+        c->cd(pad++);
+        TH1D* hIp  = new TH1D("hInvP_gf_all","GenFit #Delta(1/p) (all);1/p_{fit}-1/p_{truth} [GeV^{-1}];Tracks",60,-0.1,0.1);
+        TH1D* hIpG = new TH1D("hInvP_gf_good",Form("#chi^{2}/NDF<%.0f",chi2Cut),60,-0.1,0.1);
+        for (double v : dinvp_genfit)   hIp->Fill(v);
+        for (double v : dinvp_genfit_g) hIpG->Fill(v);
+        hIp->SetLineColor(kBlue-7);  hIp->Draw();
+        hIpG->SetLineColor(kBlue+2); hIpG->SetLineWidth(2); hIpG->Draw("SAME");
+        gPad->BuildLegend(0.55,0.7,0.98,0.92);
+
+        // 8) Analytic 1/p curvature resolution — all vs good chi2
+        c->cd(pad++);
+        TH1D* hIpA  = new TH1D("hInvP_ana_all","Analytic #Delta(1/p) (all);1/p_{ana}-1/p_{truth} [GeV^{-1}];Tracks",60,-0.1,0.1);
+        TH1D* hIpAG = new TH1D("hInvP_ana_good",Form("#chi^{2}/NDF<%.0f",chi2Cut),60,-0.1,0.1);
+        for (double v : dinvp_analytic)   hIpA->Fill(v);
+        for (double v : dinvp_analytic_g) hIpAG->Fill(v);
+        hIpA->SetLineColor(kGreen-7);  hIpA->Draw();
+        hIpAG->SetLineColor(kGreen+3); hIpAG->SetLineWidth(2); hIpAG->Draw("SAME");
+        gPad->BuildLegend(0.55,0.7,0.98,0.92);
+    } else {
+        // fallback without truth: p_fit vs p_analytic scatter
+        c->cd(pad++);
+        std::vector<double> pAnaFallback;
+        for (Long64_t ev = 0; ev < nEntries; ++ev) {
+            t->GetEntry(ev);
+            for (int tr = 0; tr < std::min(ntracks,MAXTRK); ++tr) {
+                if (!fit_ok[tr] || nDoF[tr]<=0) continue;
+                if (std::isfinite(p[tr]) && p[tr]>0 && p[tr]<PMAX
+                 && std::isfinite(p_analytic[tr]) && p_analytic[tr]>0 && p_analytic[tr]<PMAX)
+                    pAnaFallback.push_back(p_analytic[tr]);
+            }
+        }
+        TH1D* hPA = new TH1D("hPA","Analytic |p|;p_{analytic} [GeV/c];Tracks",50,0,500);
+        for (double v : pAnaFallback) hPA->Fill(v);
+        hPA->Draw();
+    }
+
+    c->SaveAs("mdt_reco_check.pdf");
+    printf("  Plots saved to mdt_reco_check.pdf\n\n");
+}

--- a/Batch/mdt_performance.C
+++ b/Batch/mdt_performance.C
@@ -1,0 +1,269 @@
+// mdt_performance.C
+// Momentum + charge resolution vs truth momentum and vs number of hits,
+// plus truth-vs-reco comparisons (momentum and charge).
+// Requires the p_truth and charge_truth branches (charge_truth added Jul 2026).
+// Usage: root -l -b -q 'mdt_performance.C("Batch-TPORecevent_6000_0_5210.root")'
+
+void mdt_performance(const char* fname = "Batch-TPORecevent_6000_0_5210.root",
+                     const char* outpdf = "mdt_performance.pdf")
+{
+    TFile* f = TFile::Open(fname);
+    if (!f || f->IsZombie()) { std::cerr << "Cannot open " << fname << "\n"; return; }
+    TTree* t = (TTree*)f->Get("MuonSpectrometer");
+    if (!t) { std::cerr << "TTree 'MuonSpectrometer' not found\n"; return; }
+
+    const bool hasTruth  = (t->GetBranch("p_truth") != nullptr);
+    const bool hasQTruth = (t->GetBranch("charge_truth") != nullptr);
+    if (!hasTruth)  { std::cerr << "[FATAL] p_truth branch not found\n"; return; }
+    if (!hasQTruth) { std::cerr << "[WARNING] charge_truth branch not found — charge plots disabled\n"; }
+
+    const int M = 10;
+    int   ntracks = 0, fit_ok[M]={}, nDoF[M]={}, npoints[M]={};
+    float p[M]={}, p_analytic[M]={}, p_truth[M]={}, chi2[M]={}, charge[M]={}, charge_truth[M]={};
+
+    t->SetBranchAddress("ntracks",      &ntracks);
+    t->SetBranchAddress("fit_ok",        fit_ok);
+    t->SetBranchAddress("nDoF",          nDoF);
+    t->SetBranchAddress("npoints",       npoints);
+    t->SetBranchAddress("p",             p);
+    t->SetBranchAddress("p_analytic",    p_analytic);
+    t->SetBranchAddress("chi2",          chi2);
+    t->SetBranchAddress("charge",        charge);
+    t->SetBranchAddress("p_truth",       p_truth);
+    if (hasQTruth) t->SetBranchAddress("charge_truth", charge_truth);
+
+    const float PMAX     = 1e4f;
+    const double chi2Cut = 10.0;
+
+    // ── log-p bins: 5 → 5000 GeV, 8 bins (coarser than mdt_resolution.C so
+    // charge mis-ID counts per bin stay statistically meaningful) ───────────
+    const int NBINS_P = 8;
+    double pEdges[NBINS_P+1];
+    for (int i = 0; i <= NBINS_P; ++i)
+        pEdges[i] = std::pow(10.0, std::log10(5.0) + i*(std::log10(5000.0)-std::log10(5.0))/NBINS_P);
+
+    // ── nhits bins: 6..12 (2..4 stations x 3 planes) ────────────────────────
+    const int NHITS_MIN = 6, NHITS_MAX = 12;
+    const int NBINS_H = NHITS_MAX - NHITS_MIN + 1;
+
+    // per-p-bin accumulators
+    std::vector<double> dinvp_bin[NBINS_P], dpp_bin[NBINS_P];
+    int   nTot_p[NBINS_P]={}, nMis_p[NBINS_P]={};
+    // per-nhits-bin accumulators
+    std::vector<double> dinvp_hbin[NBINS_H], dpp_hbin[NBINS_H];
+    int   nTot_h[NBINS_H]={}, nMis_h[NBINS_H]={};
+
+    // global vectors for truth-vs-reco plots
+    std::vector<double> pFit, pTru, dpp_all, dinvp_all;
+    int nQTot=0, nQMis=0;
+
+    TH2D* h2Charge = new TH2D("h2Charge","Charge: reco vs truth;q_{truth};q_{reco}",
+                               3,-1.5,1.5, 3,-1.5,1.5);
+    TH2D* h2P = new TH2D("h2P","p_{fit} vs p_{truth} (fit_ok, #chi^{2}/NDF<%.0f cut);p_{truth} [GeV/c];p_{fit} [GeV/c]",
+                          50,std::log10(5.0),std::log10(5000.0), 50,std::log10(5.0),std::log10(5000.0));
+
+    for (Long64_t ev = 0; ev < t->GetEntries(); ++ev) {
+        t->GetEntry(ev);
+        for (int tr = 0; tr < std::min(ntracks, M); ++tr) {
+            if (!fit_ok[tr] || nDoF[tr] <= 0) continue;
+
+            const double cndf = chi2[tr]/nDoF[tr];
+            if (cndf >= chi2Cut) continue;   // "good" sample only, for cleaner resolution/mis-ID curves
+
+            const float pt = p_truth[tr];
+            if (!(pt > 0 && pt < PMAX)) continue;
+            const int nh = npoints[tr];
+
+            // -- momentum resolution --
+            const float pf = p[tr];
+            if (std::isfinite(pf) && pf > 0 && pf < PMAX) {
+                const double dp  = (pf - pt)/pt;
+                const double dip = 1.0/pf - 1.0/pt;
+                pFit.push_back(pf); pTru.push_back(pt);
+                dpp_all.push_back(dp); dinvp_all.push_back(dip);
+                h2P->Fill(std::log10(pt), std::log10(pf));
+
+                for (int b = 0; b < NBINS_P; ++b)
+                    if (pt >= pEdges[b] && pt < pEdges[b+1])
+                        { dpp_bin[b].push_back(dp); dinvp_bin[b].push_back(dip); }
+
+                if (nh >= NHITS_MIN && nh <= NHITS_MAX) {
+                    int hb = nh - NHITS_MIN;
+                    dpp_hbin[hb].push_back(dp); dinvp_hbin[hb].push_back(dip);
+                }
+            }
+
+            // -- charge resolution / mis-ID --
+            if (hasQTruth && std::abs(charge_truth[tr]) > 0.5) {
+                const double qt = charge_truth[tr];
+                const double qf = charge[tr];
+                h2Charge->Fill(qt, qf);
+                const bool misID = (qf*qt < 0);
+                ++nQTot; if (misID) ++nQMis;
+
+                for (int b = 0; b < NBINS_P; ++b)
+                    if (pt >= pEdges[b] && pt < pEdges[b+1])
+                        { ++nTot_p[b]; if (misID) ++nMis_p[b]; }
+                if (nh >= NHITS_MIN && nh <= NHITS_MAX) {
+                    int hb = nh - NHITS_MIN;
+                    ++nTot_h[hb]; if (misID) ++nMis_h[hb];
+                }
+            }
+        }
+    }
+
+    auto vmean = [](const std::vector<double>& v)->double{
+        if (v.empty()) return 0; double s=0; for(double x:v) s+=x; return s/v.size(); };
+    auto vrms = [&](const std::vector<double>& v)->double{
+        if (v.size()<2) return 0; double mu=vmean(v),s=0;
+        for(double x:v) s+=(x-mu)*(x-mu); return std::sqrt(s/v.size()); };
+    auto binomErr = [](int k,int n)->double{
+        if (n<=0) return 0; double p=double(k)/n; return std::sqrt(p*(1-p)/n); };
+
+    printf("\n========================================\n");
+    printf("  MDT Performance Summary: %s\n", fname);
+    printf("========================================\n");
+    printf("  Momentum: N=%zu  mean(dp/p)=%+.3f RMS=%.3f  mean(d(1/p))=%+.3e RMS=%.3e\n",
+           dpp_all.size(), vmean(dpp_all), vrms(dpp_all), vmean(dinvp_all), vrms(dinvp_all));
+    if (hasQTruth)
+        printf("  Charge mis-ID rate: %d/%d = %.2f%% +/- %.2f%%\n",
+               nQMis, nQTot, nQTot? 100.0*nQMis/nQTot:0.0, nQTot? 100.0*binomErr(nQMis,nQTot):0.0);
+    printf("========================================\n\n");
+
+    // ── build resolution-vs-p graphs ────────────────────────────────────────
+    std::vector<double> xc,ex,yrInvP,eyrInvP,yrPP;
+    std::vector<double> xcMis,eyMis_lo,eyMis_hi,yMis;
+    for (int b=0;b<NBINS_P;++b) {
+        if (dinvp_bin[b].size() < 2) continue;
+        double xmid = std::sqrt(pEdges[b]*pEdges[b+1]);
+        double hw   = (pEdges[b+1]-pEdges[b])/2.0;
+        xc.push_back(xmid); ex.push_back(hw);
+        double r = vrms(dinvp_bin[b]);
+        yrInvP.push_back(r); eyrInvP.push_back(r/std::sqrt(dinvp_bin[b].size()));
+        yrPP.push_back(vrms(dpp_bin[b]));
+    }
+    if (hasQTruth) {
+        for (int b=0;b<NBINS_P;++b) {
+            if (nTot_p[b] < 5) continue;
+            double xmid = std::sqrt(pEdges[b]*pEdges[b+1]);
+            xcMis.push_back(xmid);
+            double rate = double(nMis_p[b])/nTot_p[b];
+            yMis.push_back(rate);
+            double e = binomErr(nMis_p[b], nTot_p[b]);
+            eyMis_lo.push_back(e); eyMis_hi.push_back(e);
+        }
+    }
+    int nGp = (int)xc.size();
+    TGraphErrors* grInvP = new TGraphErrors(nGp, xc.data(), yrInvP.data(), ex.data(), eyrInvP.data());
+    TGraph*       grPP   = new TGraph(nGp, xc.data(), yrPP.data());
+    int nGm = (int)xcMis.size();
+    TGraphErrors* grMisP = hasQTruth ? new TGraphErrors(nGm, xcMis.data(), yMis.data(), nullptr, eyMis_lo.data()) : nullptr;
+
+    // ── resolution / mis-ID vs nhits ────────────────────────────────────────
+    std::vector<double> xh,yrInvP_h,eyrInvP_h,yrPP_h,xhMis,yMis_h,eyMis_h;
+    for (int b=0;b<NBINS_H;++b) {
+        if (dinvp_hbin[b].size() < 2) continue;
+        xh.push_back(NHITS_MIN+b);
+        double r = vrms(dinvp_hbin[b]);
+        yrInvP_h.push_back(r); eyrInvP_h.push_back(r/std::sqrt(dinvp_hbin[b].size()));
+        yrPP_h.push_back(vrms(dpp_hbin[b]));
+    }
+    if (hasQTruth) {
+        for (int b=0;b<NBINS_H;++b) {
+            if (nTot_h[b] < 5) continue;
+            xhMis.push_back(NHITS_MIN+b);
+            yMis_h.push_back(double(nMis_h[b])/nTot_h[b]);
+            eyMis_h.push_back(binomErr(nMis_h[b], nTot_h[b]));
+        }
+    }
+    int nHp = (int)xh.size();
+    TGraphErrors* grInvP_h = new TGraphErrors(nHp, xh.data(), yrInvP_h.data(), nullptr, eyrInvP_h.data());
+    TGraph*       grPP_h   = new TGraph(nHp, xh.data(), yrPP_h.data());
+    int nHm = (int)xhMis.size();
+    TGraphErrors* grMisP_h = hasQTruth ? new TGraphErrors(nHm, xhMis.data(), yMis_h.data(), nullptr, eyMis_h.data()) : nullptr;
+
+    auto styleG = [](TGraph* g, int col, int mk){
+        g->SetLineColor(col); g->SetLineWidth(2);
+        g->SetMarkerColor(col); g->SetMarkerStyle(mk); g->SetMarkerSize(1.1); };
+    styleG(grInvP,  kBlue+1, 20);
+    styleG(grPP,    kBlue+1, 20);
+    styleG(grInvP_h,kBlue+1, 20);
+    styleG(grPP_h,  kBlue+1, 20);
+    if (grMisP)   styleG(grMisP,   kRed+1, 21);
+    if (grMisP_h) styleG(grMisP_h, kRed+1, 21);
+
+    // =========================================================================
+    TCanvas* c = new TCanvas("c","MDT Performance",1400,800);
+    c->Print(Form("%s[", outpdf));
+
+    // ── Page 1: truth vs reco momentum (2D) + charge confusion matrix ───────
+    c->Clear(); c->Divide(2,1);
+    c->cd(1);
+    h2P->GetXaxis()->SetTitle("log_{10}(p_{truth} / GeV)");
+    h2P->GetYaxis()->SetTitle("log_{10}(p_{fit} / GeV)");
+    h2P->SetTitle(Form("p_{fit} vs p_{truth} (#chi^{2}/NDF<%.0f)",chi2Cut));
+    h2P->Draw("COLZ");
+    TLine* diag = new TLine(std::log10(5.0),std::log10(5.0),std::log10(5000.0),std::log10(5000.0));
+    diag->SetLineColor(kRed); diag->SetLineWidth(2); diag->Draw();
+
+    c->cd(2);
+    if (hasQTruth) {
+        h2Charge->SetStats(0);
+        h2Charge->Draw("COLZ TEXT");
+    }
+    c->Print(Form("%s", outpdf));
+
+
+    // ── Page 2: RMS(Delta(1/p)) and RMS(Deltap/p) vs p_truth ────────────────
+    c->Clear(); c->Divide(1,2);
+    c->cd(1); gPad->SetLogx();
+    grInvP->SetTitle("RMS(#Delta(1/p)) vs p_{truth};p_{truth} [GeV/c];RMS(1/p_{fit}-1/p_{truth}) [GeV^{-1}]");
+    grInvP->Draw("APL");
+    c->cd(2); gPad->SetLogx();
+    grPP->SetTitle("RMS(#Deltap/p) vs p_{truth};p_{truth} [GeV/c];RMS((p_{fit}-p_{truth})/p_{truth})");
+    grPP->Draw("APL");
+    c->Print(Form("%s", outpdf));
+
+
+    // ── Page 3: RMS resolution vs N_hits ────────────────────────────────────
+    c->Clear(); c->Divide(1,2);
+    c->cd(1);
+    grInvP_h->SetTitle("RMS(#Delta(1/p)) vs N_{hits};N_{hits} in fit;RMS(1/p_{fit}-1/p_{truth}) [GeV^{-1}]");
+    grInvP_h->Draw("APL");
+    c->cd(2);
+    grPP_h->SetTitle("RMS(#Deltap/p) vs N_{hits};N_{hits} in fit;RMS((p_{fit}-p_{truth})/p_{truth})");
+    grPP_h->Draw("APL");
+    c->Print(Form("%s", outpdf));
+
+
+    // ── Page 4: charge mis-ID rate vs p_truth and vs N_hits ─────────────────
+    if (hasQTruth) {
+        c->Clear(); c->Divide(2,1);
+        c->cd(1); gPad->SetLogx();
+        grMisP->SetTitle("Charge mis-ID rate vs p_{truth};p_{truth} [GeV/c];mis-ID rate");
+        grMisP->GetYaxis()->SetRangeUser(0.0, std::max(0.05, 1.2*TMath::MaxElement(grMisP->GetN(),grMisP->GetY())));
+        grMisP->Draw("APL");
+        c->cd(2);
+        grMisP_h->SetTitle("Charge mis-ID rate vs N_{hits};N_{hits} in fit;mis-ID rate");
+        grMisP_h->GetYaxis()->SetRangeUser(0.0, std::max(0.05, 1.2*TMath::MaxElement(grMisP_h->GetN(),grMisP_h->GetY())));
+        grMisP_h->Draw("APL");
+        c->Print(Form("%s", outpdf));
+
+    }
+
+    // ── Page 5: Deltap/p and Delta(1/p) 1D distributions ────────────────────
+    c->Clear(); c->Divide(2,1);
+    TH1D* hDpp  = new TH1D("hDpp","#Deltap/p;(p_{fit}-p_{truth})/p_{truth};Tracks",80,-2,2);
+    TH1D* hDinv = new TH1D("hDinv","#Delta(1/p);1/p_{fit}-1/p_{truth} [GeV^{-1}];Tracks",80,-0.1,0.1);
+    for (double v: dpp_all)   hDpp->Fill(v);
+    for (double v: dinvp_all) hDinv->Fill(v);
+    hDpp->SetLineColor(kBlue+1);  hDpp->SetLineWidth(2);
+    hDinv->SetLineColor(kBlue+1); hDinv->SetLineWidth(2);
+    c->cd(1); hDpp->Draw("HIST");
+    c->cd(2); hDinv->Draw("HIST");
+    c->Print(Form("%s", outpdf));
+
+
+    c->Print(Form("%s]", outpdf));
+    printf("Saved 5-page PDF: %s\n\n", outpdf);
+}

--- a/CoreUtils/GenMagneticField.hh
+++ b/CoreUtils/GenMagneticField.hh
@@ -119,6 +119,8 @@ private:
             if (z_cm > rng.first && z_cm < rng.second) {
                 // Convert to local-like transverse coordinate.
                 // position.Y() is cm, slitposition is cm.
+                // Rotation around Y leaves Y unchanged, so global Y already
+                // equals the tilted assembly's local Y -- no correction needed.
                 double y_local_cm = position.Y() - rearMuSpec_LOS_shiftY;
                 const double y_abs = std::abs(y_local_cm);
                 // Smooth the central/outer field boundary with a 1 cm linear ramp
@@ -127,18 +129,25 @@ private:
                 const double ramp_half = 0.5; // ±0.5 cm = 1 cm total transition
                 const double lo = slitposition - ramp_half;
                 const double hi = slitposition + ramp_half;
+                double Blocal = 0.0;
                 if (y_abs < lo) {
-                    return TVector3(-15.0, 0.0, 0.0); // central: -1.5 T
-                }
-                if (y_abs < hi) {
+                    Blocal = -15.0; // central: -1.5 T
+                } else if (y_abs < hi) {
                     // Linear ramp from -15 kG to +15 kG
                     double t = (y_abs - lo) / (2.0 * ramp_half);
-                    return TVector3(-15.0 + 30.0 * t, 0.0, 0.0);
+                    Blocal = -15.0 + 30.0 * t;
+                } else if (y_abs <= 2.0 * slitposition) {
+                    Blocal = +15.0; // outer: +1.5 T
+                } else {
+                    return TVector3(0.0, 0.0, 0.0);
                 }
-                if (y_abs <= 2.0 * slitposition) {
-                    return TVector3(+15.0, 0.0, 0.0); // outer: +1.5 T
-                }
-                return TVector3(0.0, 0.0, 0.0);
+                // The field points along the Fe slab's local +x axis. rearMuSpec_tilt_deg
+                // is set to -fTiltAngleY (deg) (see TPORecoEvent.cc), so recover the
+                // detector-frame tilt (rad) and rotate the local field vector (Blocal,0,0)
+                // into global coordinates the same way TcalEvent::DetToWorld rotates
+                // local positions into the world frame, keeping B aligned with the iron.
+                const double tiltY_rad = -rearMuSpec_tilt_deg * M_PI / 180.0;
+                return TVector3(Blocal * std::cos(tiltY_rad), 0.0, Blocal * std::sin(tiltY_rad));
             }
         }
 

--- a/CoreUtils/TMuTrack.cc
+++ b/CoreUtils/TMuTrack.cc
@@ -373,11 +373,35 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     if (mdtW.Mag() > 0.0) mdtW = mdtW.Unit();
     else mdtW = mdtU.Cross(mdtV).Unit();
 
-    // Seed position: X=0 because B=(Bx,0,0) → Fx=0 → X is conserved.
-    // The 1D measurement constrains only Y at each Z; X is never measured,
-    // so GenFit's propagator stays at X=0 throughout (avoiding material
-    // corrections from traversing the MDT tube walls at global X≈900mm).
-    TVector3 posSeed(0.0,
+    // Sanity gate on px (wire direction, unmeasured): physically it should
+    // only be a small fraction of pz (~tan(tilt) ~ 0.08 here). GenFit's RK/DAF
+    // fit occasionally converges to an exotic, degenerate solution where px
+    // dominates -- the sparse per-station hits don't rule it out via chi2,
+    // even though it's unphysical for this near-axial spectrometer. Reject
+    // those so the retry/rescue cascade gets another attempt instead.
+    auto pxSane = [](const TVector3& mom) {
+        return std::fabs(mom.X()) < 0.5 * std::fabs(mom.Z()) + 1.0;
+    };
+
+    // Sanity gate on |p| against the independent analytic seed estimate
+    // (seedMomentumGeV, from the sagitta fit, tracks truth to ~20-25%). A
+    // second, distinct degenerate solution exists alongside the px runaway:
+    // a very-low-momentum trajectory can bend sharply enough to thread almost
+    // any sparse set of hits, giving excellent chi2 while being unphysical
+    // (and, empirically, this degeneracy is what breaks charge discrimination
+    // between the two RKTrackRep hypotheses). Reject fits too far from the
+    // seed in either direction.
+    const double seedMomRef = std::max(1.0, seedMomentumGeV);
+    auto pSane = [seedMomRef](const TVector3& mom) {
+        const double pmag = mom.Mag();
+        return pmag > 0.15 * seedMomRef && pmag < 6.0 * seedMomRef;
+    };
+
+    // Seed position: X from the true (tilt-aware) hit position, matching the
+    // measurement planes' origin (also hit.x_mm). With a tilted plane normal,
+    // seeding X=0 while planes sit at the true X≈900mm decouples the seed from
+    // the geometry it must intersect, which let px run away during fitting.
+    TVector3 posSeed(sortedMeas.front().x_mm * 0.1,
                      sortedMeas.front().y_mm * 0.1,
                      sortedMeas.front().z_mm * 0.1); // cm
 
@@ -413,8 +437,10 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
       ? seedMomentumGeV
       : 10.0;
 
-    // px=0: no X force, so X-momentum stays negligible.
-    TVector3 momSeed(0.0, dirGlobal.Y() * pSeed, dirGlobal.Z() * pSeed);
+    // px from dirGlobal.X(): the tilted forward direction has a small but
+    // real X-component (~sin(tilt)); seeding px=0 forced a mismatch against
+    // the tilted plane geometry.
+    TVector3 momSeed(dirGlobal.X() * pSeed, dirGlobal.Y() * pSeed, dirGlobal.Z() * pSeed);
 
     if (verbose > 0) {
         std::cout << "[GenFitMDTFit] seed pos cm = "
@@ -474,21 +500,25 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     // Instantiate the GenFit master track container.
     genfit::Track fitTrack(rep, stateSeed, covSeed);
 
-    // 1D measurement: only global Y (drift direction) is measured.
-    // Global X is unmeasured and stays ~0 (no X force from B=(Bx,0,0)).
-    // Plane normal = hU×hV = (0,1,0)×(1,0,0) = (0,0,-1) → plane ⊥ Z, natural for MDT.
+    // 1D measurement: only the drift (U) coordinate is measured; the wire (V)
+    // direction is unmeasured. Use the tilt-aware mdtU/mdtV computed above
+    // (not the global X/Y axes) so the measurement plane matches the wires'
+    // actual (tilted) orientation instead of an axis-aligned approximation.
     const double hitSigmaU_cm = 0.080 * 0.1; // 80 μm drift resolution in cm
     TMatrixDSym hitCov1D(1);
     hitCov1D.Zero();
     hitCov1D(0,0) = hitSigmaU_cm * hitSigmaU_cm;
-    const TVector3 hU_global(0.0, 1.0, 0.0); // measured: global Y (drift direction)
-    const TVector3 hV_global(1.0, 0.0, 0.0); // unmeasured: global X (wire direction)
+    const TVector3& hU_global = mdtU; // measured: drift direction
+    const TVector3& hV_global = mdtV; // unmeasured: wire direction
 
     const int detId = 0;
     int hitCounter = 0;
     for (const auto& hit : sortedMeas) {
-        // X=0: no X force so particle stays at X=0 throughout.
-        TVector3 planeOrigin(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
+        // Use the true global X (from hit.x_mm) as the plane origin: with a
+        // tilted hV_global (wire direction), a wrong origin X is no longer
+        // "along the unmeasured axis only" -- it now has a component along
+        // the plane normal (hU x hV) and would offset the whole plane.
+        TVector3 planeOrigin(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1);
 
         TVectorD hitCoords(1);
         hitCoords(0) = 0.0; // measured Y = planeOrigin.Y() = hit.y_mm/10
@@ -596,7 +626,8 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
     // Quality gate: accept if GenFit declares convergence OR chi2/NDF is reasonable.
     // With 1D global-axis measurements the fitter is numerically stable, so
     // isFitConverged() is reliable.  Keep chi2/NDF < 100 as a safety backstop.
-    const bool qualityOk = status->isFitConverged() || ((fitNDF > 0) && (chi2ndf < 100.0));
+    const bool qualityOk = (status->isFitConverged() || ((fitNDF > 0) && (chi2ndf < 100.0)))
+                         && pxSane(state.getMom()) && pSane(state.getMom());
     // Also trigger retry if too many hits were silently rejected: a "converged" fit
     // that keeps only 6 of 12 hits (NDF=1 vs expected NDF=7) is not acceptable.
     const int expectedNDF = (int)sortedMeas.size() - 5;
@@ -641,10 +672,11 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
         // Second GenFit attempt with corrected measurements, 1D global planes.
         genfit::AbsTrackRep* rep2 = new genfit::RKTrackRep(pdg);
 
-        // Seed from partial state, zeroing X (conserved; keeps propagator at X=0).
+        // Seed from partial state, keeping its own X/px (consistent with the
+        // tilted, true-X measurement planes -- zeroing X here would mismatch them).
         TVectorD stateSeed2(6);
-        stateSeed2(0) = 0.0;            stateSeed2(1) = posPartial.Y(); stateSeed2(2) = posPartial.Z();
-        stateSeed2(3) = 0.0;            stateSeed2(4) = pPartial.Y();   stateSeed2(5) = pPartial.Z();
+        stateSeed2(0) = posPartial.X(); stateSeed2(1) = posPartial.Y(); stateSeed2(2) = posPartial.Z();
+        stateSeed2(3) = pPartial.X();   stateSeed2(4) = pPartial.Y();   stateSeed2(5) = pPartial.Z();
         TMatrixDSym covSeed2(6); covSeed2.Zero();
         for (int i = 0; i < 3; ++i) covSeed2(i,i) = 1.0;
         const double mSig2 = std::max(5.0, 0.3 * pPartial.Mag());
@@ -655,7 +687,7 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
 
         int hitCtr2 = 0;
         for (const auto& hit : sortedMeas) {
-            TVector3 origin2(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
+            TVector3 origin2(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1);
             TVectorD hc2(1); hc2(0) = 0.0;
             TMatrixDSym hCov2(1); hCov2.Zero();
             hCov2(0,0) = hitSigmaU_cm * hitSigmaU_cm;
@@ -685,16 +717,17 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
         try { state2 = fitTrack2.getFittedState(); }
         catch (...) { return false; }
 
-        const bool qualityOk2 = status2->isFitConverged() || ((ndf_2 > 0) && (chi2ndf_2 < 100.0));
+        const bool qualityOk2 = (status2->isFitConverged() || ((ndf_2 > 0) && (chi2ndf_2 < 100.0)))
+                              && pxSane(state2.getMom()) && pSane(state2.getMom());
         if (!qualityOk2) {
             // Attempt 3+: try multiple seed momenta (1D global planes throughout).
             static const double altSeeds[] = { 5.0, 20.0, 100.0 };
             for (double altP : altSeeds) {
                 genfit::AbsTrackRep* rep3 = new genfit::RKTrackRep(pdg);
                 TVectorD ss3(6);
-                // X=0 always; use Y/Z from analytic direction scaled to altP.
-                ss3(0) = 0.0; ss3(1) = posSeed.Y(); ss3(2) = posSeed.Z();
-                TVector3 d3(0.0, dirGlobal.Y() * altP, dirGlobal.Z() * altP);
+                // X from the true hit position (matches the tilted plane geometry).
+                ss3(0) = posSeed.X(); ss3(1) = posSeed.Y(); ss3(2) = posSeed.Z();
+                TVector3 d3(dirGlobal.X() * altP, dirGlobal.Y() * altP, dirGlobal.Z() * altP);
                 ss3(3) = d3.X(); ss3(4) = d3.Y(); ss3(5) = d3.Z();
                 TMatrixDSym cs3(6); cs3.Zero();
                 for (int i = 0; i < 3; ++i) cs3(i,i) = 1.0;
@@ -703,7 +736,7 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
                 genfit::Track ft3(rep3, ss3, cs3);
                 int hc3 = 0;
                 for (const auto& hit : sortedMeas) {
-                    TVector3 org3(0.0, hit.y_mm*0.1, hit.z_mm*0.1);
+                    TVector3 org3(hit.x_mm*0.1, hit.y_mm*0.1, hit.z_mm*0.1);
                     TVectorD hc3v(1); hc3v(0) = 0.0;
                     TMatrixDSym hCov3(1); hCov3.Zero();
                     hCov3(0,0) = hitSigmaU_cm*hitSigmaU_cm;
@@ -724,6 +757,7 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
                 if (!st3->isFitConverged() && ((n3 <= 0) || (cn3 >= 100.0))) continue;
                 genfit::MeasuredStateOnPlane st3s;
                 try { st3s = ft3.getFittedState(); } catch (...) { continue; }
+                if (!pxSane(st3s.getMom()) || !pSane(st3s.getMom())) continue;
                 TVector3 p3 = st3s.getMom();
                 fpx = p3.X(); fpy = p3.Y(); fpz = p3.Z(); fp = p3.Mag();
                 fcharge = st3s.getCharge();
@@ -749,8 +783,9 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
             {
                 genfit::AbsTrackRep* repD = new genfit::RKTrackRep(pdg);
                 TVectorD ssD(6);
-                ssD(0) = 0.0; ssD(1) = posSeed.Y(); ssD(2) = posSeed.Z();
-                TVector3 dD(0.0, dirGlobal.Y() * seedMomentumGeV,
+                ssD(0) = posSeed.X(); ssD(1) = posSeed.Y(); ssD(2) = posSeed.Z();
+                TVector3 dD(dirGlobal.X() * seedMomentumGeV,
+                                 dirGlobal.Y() * seedMomentumGeV,
                                  dirGlobal.Z() * seedMomentumGeV);
                 ssD(3) = dD.X(); ssD(4) = dD.Y(); ssD(5) = dD.Z();
                 TMatrixDSym csD(6); csD.Zero();
@@ -761,7 +796,7 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
                 genfit::Track ftD(repD, ssD, csD);
                 int hcD = 0;
                 for (const auto& hit : sortedMeas) {
-                    TVector3 orgD(0.0, hit.y_mm * 0.1, hit.z_mm * 0.1);
+                    TVector3 orgD(hit.x_mm * 0.1, hit.y_mm * 0.1, hit.z_mm * 0.1);
                     TVectorD hcDv(1); hcDv(0) = 0.0;
                     TMatrixDSym hCovD(1); hCovD.Zero();
                     hCovD(0,0) = hitSigmaU_cm * hitSigmaU_cm;
@@ -807,13 +842,14 @@ bool TMuTrack::GenFitMDTFit(const std::vector<MDTMeas>& meas,
                 // hits can inflate the ratio slightly.
                 // Require effective NDF >= 1 (at least one hit with significant
                 // weight survived annealing) and physical momentum (< 10 TeV).
-                const bool qualityDAF = (stD->isFitConverged() || ((nD > 0) && (cnD < 200.0)))
-                                        && (nD >= 1.0) && (cnD < 200.0);
-                if (!qualityDAF) return false;
-
                 genfit::MeasuredStateOnPlane stDs;
                 try { stDs = ftD.getFittedState(); }
                 catch (...) { return false; }
+
+                const bool qualityDAF = (stD->isFitConverged() || ((nD > 0) && (cnD < 200.0)))
+                                        && (nD >= 1.0) && (cnD < 200.0)
+                                        && pxSane(stDs.getMom()) && pSane(stDs.getMom());
+                if (!qualityDAF) return false;
 
                 TVector3 pD = stDs.getMom();
                 fpx = pD.X(); fpy = pD.Y(); fpz = pD.Z(); fp = pD.Mag();

--- a/CoreUtils/TMuTrack.hh
+++ b/CoreUtils/TMuTrack.hh
@@ -62,7 +62,7 @@ public:
 
     bool   ffit_ok;     // true if GenFit Kalman converged
     double fpAnalytic;  // analytic sagitta-fit momentum (GeV/c), always filled
-    
+
     TMuTrack() : ftrackID(-1), fcharge(0), fitTrack(nullptr), ffit_ok(false), fpAnalytic(0.0) {}
     virtual ~TMuTrack() {
         if (fitTrack) {

--- a/CoreUtils/TMuonSpect.cc
+++ b/CoreUtils/TMuonSpect.cc
@@ -19,4 +19,6 @@ void TMuonSpectrometer::Create_Sel_Tree(TTree *t) {
   t->Branch("fipErr", &features.fipErr, "fipErr[ntracks]/F");
   t->Branch("fit_ok", &features.fit_ok, "fit_ok[ntracks]/I");
   t->Branch("p_analytic", &features.p_analytic, "p_analytic[ntracks]/F");
+  t->Branch("p_truth", &features.p_truth, "p_truth[ntracks]/F");
+  t->Branch("charge_truth", &features.charge_truth, "charge_truth[ntracks]/F");
 };

--- a/CoreUtils/TMuonSpect.hh
+++ b/CoreUtils/TMuonSpect.hh
@@ -30,12 +30,14 @@ struct FEATURES {
     float fipErr[MAXMUTRACKS]; // error on fitted inverse momentum at the first point
      int   fit_ok[MAXMUTRACKS];     // 1 if GenFit Kalman converged, 0 otherwise
     float p_analytic[MAXMUTRACKS]; // analytic sagitta-fit momentum (GeV/c)
+    float p_truth[MAXMUTRACKS];    // truth |p| at first MDT hit (GeV/c), from MDTTrack::mom[0]/1000
+    float charge_truth[MAXMUTRACKS]; // truth charge (+1/-1) from MDTTrack::fPDG sign, -999 if unmatched
 };
 
 private:
 
 public:
-    ClassDef(TMuonSpectrometer, 3)
+    ClassDef(TMuonSpectrometer, 4);
 
     struct FEATURES features;
 

--- a/CoreUtils/TPORecoEvent.cc
+++ b/CoreUtils/TPORecoEvent.cc
@@ -4268,6 +4268,7 @@ void TPORecoEvent::ReconstructMDT()
         }
 
 
+
         // ---------------------------------------------------------------------
         // Analytic local y(z) fit using refined L/R assignment.
         // (kernelY already computed above)
@@ -4553,18 +4554,53 @@ void TPORecoEvent::ReconstructMDT()
             : seedMomentumGeV;
 
         trk.fpAnalytic = pAnalytic;
-        // Use the analytic charge sign for the GenFit PDG so that the
-        // RKTrackRep charge matches the bending direction implied by the L/R
-        // assignment.  When the per-station L/R picks the mirror image, the
-        // analytic fit gives the opposite charge sign; using it keeps GenFit's
-        // propagation consistent with the measurements.
-        const int pdgForFit = (qAnalytic > 0.0) ? -13 : 13;  // +1 → mu+, -1 → mu-
-        if (pdgForFit != mdt->fPDG) {
-            std::cout << "[ReconstructMDT] Charge flip: analytic q=" << qAnalytic
-                      << " differs from truth PDG=" << mdt->fPDG
-                      << " → using PDG=" << pdgForFit << " for GenFit\n";
+        // Charge comes from GenFit, not the analytic pre-fit: the analytic
+        // model's qp sign was found to be a coin flip even with perfect L/R
+        // (likely slope/curvature near-degeneracy over the narrow station
+        // baseline), so it can't be trusted to pick the RKTrackRep charge
+        // hypothesis. Instead, fit both hypotheses through the real nonlinear
+        // RK/Kalman propagation and keep whichever one actually fits better.
+        TMuTrack trkMuMinus, trkMuPlus;
+        trkMuMinus.ftrackID = tid; trkMuMinus.fPDG = mdt->fPDG; trkMuMinus.fpAnalytic = pAnalytic;
+        trkMuPlus.ftrackID  = tid; trkMuPlus.fPDG  = mdt->fPDG; trkMuPlus.fpAnalytic  = pAnalytic;
+        const bool okMinus = trkMuMinus.GenFitMDTFit(meas, 13,  seedPForGenFit, 1 /*verbose*/, bestP[1]);
+        const bool okPlus  = trkMuPlus.GenFitMDTFit(meas, -13, seedPForGenFit, 1 /*verbose*/, bestP[1]);
+
+        // KNOWN LIMITATION (investigated 2026-07): the fitted charge is not
+        // reliable, and no per-track signal currently available here (chi2,
+        // pval, NDF, or which hypothesis converged) separates correct from
+        // incorrect charge -- it is close to a coin flip (~45-50% mis-ID)
+        // even when both hypotheses are fit through the full nonlinear
+        // RK/Kalman propagation and the better chi2/NDF is kept below. This
+        // was checked directly: even tracks where BOTH hypotheses converge
+        // with a clearly-separated chi2/NDF are wrong about as often as
+        // tracks where only one hypothesis converges "cleanly". Root cause
+        // is believed to be a genuine degeneracy of this 1D-measurement,
+        // few-station geometry (a low-momentum, sharply-curved trajectory
+        // can thread almost any sparse hit pattern under either charge
+        // hypothesis), not a fixable bug in this fit. Do not treat fcharge
+        // as trustworthy until this is revisited with additional
+        // information (e.g. an independent upstream charge/direction
+        // measurement).
+        int pdgForFit;
+        if (okMinus && okPlus) {
+            const double cndfMinus = (trkMuMinus.fnDoF > 0) ? trkMuMinus.fchi2 / trkMuMinus.fnDoF : 1e18;
+            const double cndfPlus  = (trkMuPlus.fnDoF  > 0) ? trkMuPlus.fchi2  / trkMuPlus.fnDoF  : 1e18;
+            if (cndfMinus <= cndfPlus) { trk = trkMuMinus; pdgForFit = 13; }
+            else                       { trk = trkMuPlus;  pdgForFit = -13; }
+        } else if (okMinus) {
+            trk = trkMuMinus; pdgForFit = 13;
+        } else if (okPlus) {
+            trk = trkMuPlus; pdgForFit = -13;
+        } else {
+            pdgForFit = (qAnalytic > 0.0) ? -13 : 13;  // both failed; keep a definite PDG for the rescue path below
         }
-        bool ok = trk.GenFitMDTFit(meas, pdgForFit, seedPForGenFit, 1 /*verbose*/, bestP[1]);
+        bool ok = okMinus || okPlus;
+        if (pdgForFit != mdt->fPDG) {
+            std::cout << "[ReconstructMDT] Charge from GenFit: chose PDG=" << pdgForFit
+                      << " (truth PDG=" << mdt->fPDG
+                      << ", analytic q=" << qAnalytic << ")\n";
+        }
 
         // Outlier-rejection rescue: when the full-hit fit fails AND we have
         // enough hits, iteratively remove the hit(s) most inconsistent with the
@@ -4957,8 +4993,33 @@ void TPORecoEvent::DumpRearHCalTruth(int maxPrint, bool uniquePerModuleAndTrack)
 // Converts energy deposits (MeV) to photoelectrons (PE)
 //////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-// DETECTOR RESPONSE MODEL FOR FASERCAL
+// FIBER READOUT GEOMETRY (11 × 48 × 48 voxels per layer)
 // 
+// Three sets of wavelength-shifting (WLS) fibers run through the detector:
+//
+// X-FIBERS (2304 fibers):
+//   - Run along X-direction through all 11 voxels
+//   - One fiber per (Y, Z) position: 48 × 48 = 2,304 fibers
+//   - Each fiber passes through 11 voxels: (0,j,k), (1,j,k), ..., (10,j,k)
+//   - SiPM readout at +X face (maximum X position)
+//
+// Y-FIBERS (5328 fibers):
+//   - Run along Y-direction through all 48 voxels
+//   - One fiber per (X, Z) position: 11 × 48 = 528 fibers
+//   - Each fiber passes through 48 voxels: (i,0,k), (i,1,k), ..., (i,47,k)
+//   - SiPM readout at +Y face (maximum Y position)
+//
+// Z-FIBERS (528 fibers per layer):
+//   - Run along Z-direction within each layer module (48 voxels deep)
+//   - One fiber per (X, Y) position: 11 × 48 = 528 fibers per layer
+//   - Each fiber passes through 48 voxels: (i,j,0), (i,j,1), ..., (i,j,47)
+//   - SiPM readout at +Z face (downstream end of each layer module)
+//
+// LIGHT COLLECTION:
+//   Each voxel contributes scintillation light to exactly 3 fibers (X, Y, Z).
+//   Light propagates along fiber to SiPM, attenuated by distance traveled.
+//
+// DETECTOR RESPONSE MODEL:
 // Formula: NPE = NumberOfPhotonPerMeV × EnergyDeposit × globalFiberCapture 
 //                × FiberTrappingEfficiency × attenuation × SiPM_PDE
 //
@@ -4968,10 +5029,10 @@ void TPORecoEvent::DumpRearHCalTruth(int maxPrint, bool uniquePerModuleAndTrack)
 // 3. globalFiberCapture: Combined light collection efficiency (~10%)
 //    Includes: isotropic emission, geometric coupling, light transport, reflection
 // 4. FiberTrappingEfficiency: Fraction of photons trapped in WLS fiber (~5%)
-// 5. attenuation: Exponential decay along fiber length exp(-L/L_att)
+// 5. attenuation: Exponential decay along fiber length (dual-component model)
 // 6. SiPM_PDE: Photodetector efficiency (~25%)
 //
-// This model is applied separately for X, Y, and Z fiber readouts
+// This model is applied independently for X, Y, and Z fiber readouts
 ////////////////////////////////////////////////////////////////////////////////
 bool TPORecoEvent::decodeFaserCalScintID(long id, int& ix, int& iy, int& iz, int& ilayer) {
     const long hittype = id / 100000000000LL;
@@ -4995,7 +5056,8 @@ bool TPORecoEvent::isValidFaserCalVoxelIndex(int ix, int iy, int iz, int ilayer)
     const auto& g = geom_detector;
     const int nx = static_cast<int>(g.fScintillatorSizeX / g.fScintillatorVoxelSize);
     const int ny = static_cast<int>(g.fScintillatorSizeY / g.fScintillatorVoxelSize);
-    const int nzPerLayer = std::max(1, static_cast<int>(g.fSandwichLength / g.fScintillatorVoxelSize));
+    // Use fScintillatorSizeZ (pure scintillator thickness) instead of fSandwichLength (includes Al plates)
+    const int nzPerLayer = std::max(1, static_cast<int>(g.fScintillatorSizeZ / g.fScintillatorVoxelSize));
     
     if (ix < 0 || ix >= nx) return false;
     if (iy < 0 || iy >= ny) return false;
@@ -5005,7 +5067,8 @@ bool TPORecoEvent::isValidFaserCalVoxelIndex(int ix, int iy, int iz, int ilayer)
 }
 
 double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDepositMeV,
-                                              std::array<double, 3>& fiberPE) {
+                                              std::array<double, 3>& fiberPE,
+                                              bool applyStatistics) {
     fiberPE = {0.0, 0.0, 0.0};
     if (energyDepositMeV <= 0.0) return 0.0;
     
@@ -5022,9 +5085,9 @@ double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDeposi
 	// STEP 1: Determine voxel center position in detector coordinates (mm)
 	// ========================================================================
     const double voxelX = ix * g.fScintillatorVoxelSize - g.fScintillatorSizeX / 2.0 + 
-                          g.fScintillatorVoxelSize / 2.0 + g.fFASERCal_LOS_shiftX;
+                          g.fScintillatorVoxelSize / 2.0 + g.fFASERCal_LOS_shiftX + g.fThreeD_CAL_shiftX;
     const double voxelY = iy * g.fScintillatorVoxelSize - g.fScintillatorSizeY / 2.0 + 
-                          g.fScintillatorVoxelSize / 2.0 + g.fFASERCal_LOS_shiftY;
+                          g.fScintillatorVoxelSize / 2.0 + g.fFASERCal_LOS_shiftY + g.fThreeD_CAL_shiftY;
     const double voxelZ = ilayer * g.fSandwichLength + iz * g.fScintillatorVoxelSize -
                           (g.NRep * g.fSandwichLength) / 2.0 + g.fScintillatorVoxelSize / 2.0 +
                           g.fAlPlateThickness + g.fTargetSizeZ;
@@ -5032,23 +5095,82 @@ double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDeposi
   	// ========================================================================
 	// STEP 2: Calculate fiber path lengths from voxel to readout (mm)
 	// ========================================================================
-    const double distX = cfg.faserCal_readoutAtPositiveX ? 
-                         (g.fScintillatorSizeX / 2.0 - voxelX + g.fFASERCal_LOS_shiftX) :
-                         (voxelX + g.fScintillatorSizeX / 2.0 - g.fFASERCal_LOS_shiftX);
-    const double distY = cfg.faserCal_readoutAtPositiveY ?
-                         (g.fScintillatorSizeY / 2.0 - voxelY + g.fFASERCal_LOS_shiftY) :
-                         (voxelY + g.fScintillatorSizeY / 2.0 - g.fFASERCal_LOS_shiftY);
-    const double distZ = cfg.faserCal_readoutAtPositiveZ ?
-                         (g.fTotalLength / 2.0 - voxelZ) :
-                         (voxelZ + g.fTotalLength / 2.0);
-    
-    // ========================================================================
-	// STEP 3: Calculate attenuation factor = exp(-distance/attenuationLength)
+	// FIBER GEOMETRY (11 x 48 x 48 voxels per layer):
+	// - X-fibers: Run line-by-line along X-direction (11 voxels long)
+	//   Each fiber at fixed (Y=j, Z=k) collects light from voxels (i=0..10, j, k)
+	//   Readout at +X face (maximum X position)
+	// 
+	// - Y-fibers: Run line-by-line along Y-direction (48 voxels long)
+	//   Each fiber at fixed (X=i, Z=k) collects light from voxels (i, j=0..47, k)
+	//   Readout at +Y face (maximum Y position)
+	// 
+	// - Z-fibers: Run line-by-line along Z-direction within each layer
+	//   Each fiber at fixed (X=i, Y=j) collects light from voxels (i, j, k=0..47)
+	//   Readout at +Z face (maximum Z within layer)
+	//
+	// Distance calculation: Light from each voxel propagates along the fiber
+	// to the readout end. Distance = path length remaining to reach SiPM.
 	// ========================================================================
 
-    const double attenuationX = std::exp(-distX / cfg.faserCal_fiberAttenuationLengthX);
-    const double attenuationY = std::exp(-distY / cfg.faserCal_fiberAttenuationLengthY);
-    const double attenuationZ = std::exp(-distZ / cfg.faserCal_fiberAttenuationLengthZ);
+    // X-fiber distance: from this voxel to the +X edge
+    const double distX = g.fScintillatorSizeX / 2.0 - voxelX + g.fFASERCal_LOS_shiftX + g.fThreeD_CAL_shiftX;
+    
+    // Y-fiber distance: from this voxel to the +Y edge  
+    const double distY = g.fScintillatorSizeY / 2.0 - voxelY + g.fFASERCal_LOS_shiftY + g.fThreeD_CAL_shiftY;
+    
+    // Z-fiber distance: from this voxel to the +Z edge within the layer module
+    // Fibers run within each layer module and are read out at the downstream end
+    const int nLayersPerModule = static_cast<int>(g.fSandwichLength / g.fScintillatorVoxelSize);
+    const double distZ = (nLayersPerModule - iz - 0.5) * g.fScintillatorVoxelSize;
+    
+    if (verbose > 1) {
+        std::cout << "[DEBUG Fiber geometry] Voxel indices: (ix=" << ix << ", iy=" << iy << ", iz=" << iz << ")" << std::endl;
+        std::cout << "[DEBUG Fiber geometry] Module layer=" << ilayer << ", voxels per layer=" << nLayersPerModule << std::endl;
+        std::cout << "[DEBUG Fiber distances to +readout (mm)]:" << std::endl;
+        std::cout << "  X-fiber: distX=" << distX << " (to +X edge)" << std::endl;
+        std::cout << "  Y-fiber: distY=" << distY << " (to +Y edge)" << std::endl;
+        std::cout << "  Z-fiber: distZ=" << distZ << " (to +Z edge in layer)" << std::endl;
+    }
+    
+    // ========================================================================
+	// STEP 3: Calculate attenuation factor with dual-component model
+	// Model: Attenuation = f_short * exp(-d/L_short) + (1-f_short) * exp(-d/L_long)
+	// This accounts for both bulk attenuation (short) and Rayleigh scattering (long)
+	// ========================================================================
+
+    // X fiber attenuation
+    const double attenuationX_short = std::exp(-distX / cfg.faserCal_fiberAttenuationLengthShortX);
+    const double attenuationX_long = std::exp(-distX / cfg.faserCal_fiberAttenuationLengthLongX);
+    const double attenuationX = cfg.faserCal_fiberShortComponentFractionX * attenuationX_short +
+                                (1.0 - cfg.faserCal_fiberShortComponentFractionX) * attenuationX_long;
+    
+    // Y fiber attenuation
+    const double attenuationY_short = std::exp(-distY / cfg.faserCal_fiberAttenuationLengthShortY);
+    const double attenuationY_long = std::exp(-distY / cfg.faserCal_fiberAttenuationLengthLongY);
+    const double attenuationY = cfg.faserCal_fiberShortComponentFractionY * attenuationY_short +
+                                (1.0 - cfg.faserCal_fiberShortComponentFractionY) * attenuationY_long;
+    
+    // Z fiber attenuation
+    const double attenuationZ_short = std::exp(-distZ / cfg.faserCal_fiberAttenuationLengthShortZ);
+    const double attenuationZ_long = std::exp(-distZ / cfg.faserCal_fiberAttenuationLengthLongZ);
+    const double attenuationZ = cfg.faserCal_fiberShortComponentFractionZ * attenuationZ_short +
+                                (1.0 - cfg.faserCal_fiberShortComponentFractionZ) * attenuationZ_long;
+    
+    if (verbose > 1) {
+        std::cout << "[DEBUG Attenuation] Dual-component model (light traveling to +readout):" << std::endl;
+        std::cout << "  X-fiber (" << distX << " mm to +X SiPM):" << std::endl;
+        std::cout << "     Short(L=" << cfg.faserCal_fiberAttenuationLengthShortX << "mm): " << attenuationX_short << std::endl;
+        std::cout << "     Long(L=" << cfg.faserCal_fiberAttenuationLengthLongX << "mm): " << attenuationX_long << std::endl;
+        std::cout << "     Combined(f=" << cfg.faserCal_fiberShortComponentFractionX << "): " << attenuationX << std::endl;
+        std::cout << "  Y-fiber (" << distY << " mm to +Y SiPM):" << std::endl;
+        std::cout << "     Short(L=" << cfg.faserCal_fiberAttenuationLengthShortY << "mm): " << attenuationY_short << std::endl;
+        std::cout << "     Long(L=" << cfg.faserCal_fiberAttenuationLengthLongY << "mm): " << attenuationY_long << std::endl;
+        std::cout << "     Combined(f=" << cfg.faserCal_fiberShortComponentFractionY << "): " << attenuationY << std::endl;
+        std::cout << "  Z-fiber (" << distZ << " mm to +Z SiPM):" << std::endl;
+        std::cout << "     Short(L=" << cfg.faserCal_fiberAttenuationLengthShortZ << "mm): " << attenuationZ_short << std::endl;
+        std::cout << "     Long(L=" << cfg.faserCal_fiberAttenuationLengthLongZ << "mm): " << attenuationZ_long << std::endl;
+        std::cout << "     Combined(f=" << cfg.faserCal_fiberShortComponentFractionZ << "): " << attenuationZ << std::endl;
+    }
     
     // ========================================================================
 	// STEP 4: Calculate total scintillation photons produced
@@ -5077,10 +5199,10 @@ double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDeposi
     double meanPE_Z = commonFactor * attenuationZ;
     
     // ========================================================================
-	// STEP 7: Apply Poisson statistics (optional)
+	// STEP 6: Apply Poisson statistics (optional)
 	// ========================================================================
 	// Simulate the statistical fluctuations in photoelectron production
-    if (cfg.faserCal_applyPoissonStatistics) {
+    if (applyStatistics && cfg.faserCal_applyPoissonStatistics) {
         // Use Poisson distribution (approximated with Gaussian for large means)
         /*
         std::random_device rd;
@@ -5133,29 +5255,65 @@ double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDeposi
     // ========================================================================
 	// EXAMPLE CALCULATION (typical values):
 	// ========================================================================
-	// Input: 1 MeV energy deposit in center voxel (10mm cube)
-	// 
+	// Consider a voxel at position (ix=5, iy=24, iz=24) - approximately center
+	// Detector size: 11×48×48 voxels, 10mm voxel size
+	// (X extent = 11×10 = 110mm; Y extent = 48×10 = 480mm; Z extent per layer = 480mm)
+	//
+	// This voxel contributes light to 3 fibers:
+	//   - X-fiber running through (0→10, 24, 24), readout at +X edge
+	//   - Y-fiber running through (5, 0→47, 24), readout at +Y edge
+	//   - Z-fiber running through (5, 24, 0→47), readout at +Z edge
+	//
+	// Assume: 1 MeV energy deposit in this voxel
+	//
 	// Step 1: Scintillation photons
 	//   N_scint = 1 MeV × 8000 photons/MeV = 8000 photons total
 	//
-	// Step 2: Global fiber capture (10%)
-	//   This single parameter includes:
-	//     - Isotropic light emission from scintillator
-	//     - Geometric coupling to fiber/groove
-	//     - Light transport within voxel
-	//     - Internal reflection effects
-	//   Photons coupled = 8000 × 0.10 = 800 photons
+	// Step 2: Global fiber capture per direction (10%)
+	//   Each fiber (X, Y, Z) captures: 8000 × 0.10 = 800 photons
+	//   (This includes geometric coupling, light transport, reflection)
 	//
 	// Step 3: Fiber trapping efficiency (5%)
-	//   Trapped = 800 × 0.05 = 40 photons
+	//   Trapped in each fiber: 800 × 0.05 = 40 photons
 	//
-	// Step 4: Attenuation (assume 50mm distance, 3000mm atten. length)
-	//   att = exp(-50/3000) = 0.983
-	//   After attenuation = 40 × 0.983 = 39 photons
+	// Step 4: Attenuation (dual-component model)
+	//   Distance to +X readout: ~55 mm (center voxel to +X edge, 110mm extent)
+	//   Distance to +Y readout: ~235 mm (center voxel to +Y edge, 480mm extent)
+	//   Distance to +Z readout: ~235 mm (center voxel to +Z edge within layer, 480mm extent)
+	//
+	//   X-fiber (55mm distance, f_short=0.29, L_short=350mm, L_long=4000mm):
+	//     att_short = exp(-55/350)  = 0.850
+	//     att_long  = exp(-55/4000) = 0.986
+	//     att_combined = 0.29×0.850 + 0.71×0.986 = 0.947
+	//   After attenuation: 40 × 0.947 = 37.9 photons reach +X SiPM
+	//
+	//   Y-fiber (235mm distance, f_short=0.29, L_short=350mm, L_long=4000mm):
+	//     att_short = exp(-235/350)  = 0.512
+	//     att_long  = exp(-235/4000) = 0.943
+	//     att_combined = 0.29×0.512 + 0.71×0.943 = 0.817
+	//   After attenuation: 40 × 0.817 = 32.7 photons reach +Y SiPM
+	//
+	//   Z-fiber (235mm distance, f_short=0.33, L_short=430mm, L_long=5000mm):
+	//     att_short = exp(-235/430)  = 0.579
+	//     att_long  = exp(-235/5000) = 0.955
+	//     att_combined = 0.33×0.579 + 0.67×0.955 = 0.831
+	//   After attenuation: 40 × 0.831 = 33.2 photons reach +Z SiPM
 	//
 	// Step 5: SiPM photodetection (25% PDE)
-	//   PE = 39 × 0.25 = 10 photoelectrons per fiber
-	//   Total (X+Y+Z) ≈ 30 PE for 1 MeV (typical ~20-30 PE/MeV)
+	//   PE_X = 37.9 × 0.25 = 9.5 photoelectrons
+	//   PE_Y = 32.7 × 0.25 = 8.2 photoelectrons
+	//   PE_Z = 33.2 × 0.25 = 8.3 photoelectrons
+	//
+	//   Total: ~26 PE for 1 MeV center voxel (~20-30 PE/MeV typical)
+	//
+	// NOTE: Position dependence differs by axis because of the very different
+	// extents (110mm in X vs 480mm in Y/Z) relative to the ~350-5000mm
+	// attenuation lengths:
+	//   - X-fiber response varies only mildly across the full 110mm width
+	//     (e.g. PE_X ≈ 10.0 at ix=10 near the SiPM vs ≈ 9.1 at ix=0, the far edge)
+	//   - Y/Z-fiber response varies more strongly across their 480mm extent
+	//     (voxels near the +Y/+Z SiPM see substantially more PE than voxels
+	//     near the far -Y/-Z edge)
 	// ========================================================================
     return meanPE_X + meanPE_Y + meanPE_Z;
 }
@@ -5165,22 +5323,24 @@ double TPORecoEvent::computeFaserCalDirectPE(long channelID, double energyDeposi
 // Distributes energy among voxels before PE conversion to account for
 // optical photon leakage to neighboring voxels
 //
-// Configuration:
-//   opticalLeakageSide: fraction of light leaking to each of 4 side faces (±X, ±Y)
-//   opticalLeakageZ: fraction leaking to ±Z neighbors (not currently used)
+// Configuration (measured from data, see recoConfig comments for derivation):
+//   opticalLeakageSideX: fraction of light leaking to each of the ±X neighbors
+//   opticalLeakageSideY: fraction of light leaking to each of the ±Y neighbors
+//   opticalLeakageZ: fraction of light leaking to each of the ±Z (in-layer,
+//                    fiber-depth) neighbors - separate axis, not directly
+//                    measured; set to avg(SideX, SideY) as a placeholder
 //
-// Example with opticalLeakageSide = 0.03 (3% per face):
-//   - 3% --> left neighbor (ix-1)
-//   - 3% --> right neighbor (ix+1)
-//   - 3% --> bottom neighbor (iy-1)
-//   - 3% --> top neighbor (iy+1)
-//   - 88% --> central voxel (1.0 - 4×0.03)
+// Example with current defaults (SideX~0.258%, SideY~0.269%, Z~0.264%):
+//   - 0.258% --> left/right neighbor (ix-1 / ix+1)      [opticalLeakageSideX]
+//   - 0.269% --> bottom/top neighbor (iy-1 / iy+1)       [opticalLeakageSideY]
+//   - 0.264% --> back/front neighbor (iz-1 / iz+1, same layer) [opticalLeakageZ]
+//   - ~98.4% --> central voxel (1.0 - 2*SideX - 2*SideY - 2*Z)
 //
 // IMPORTANT: Voxels can receive light FROM neighbors WITHOUT direct particle hits!
 // Example:
-//   - Particle hits voxel A with large energy --> neighbors B,C,D,E each get 3% leakage
-//   - Voxel B might have NO direct hit, but still gets PE from leaked light
-//   - If another particle later hits voxel B directly, both contributions accumulate
+//   - Particle hits voxel A with large energy --> its neighbors each get their leakage share
+//   - A neighbor might have NO direct hit, but still gets PE from leaked light
+//   - If another particle later hits that neighbor directly, both contributions accumulate
 //
 // ========================================================================
 void TPORecoEvent::accumulateFaserCalPEWithCrosstalk(
@@ -5196,16 +5356,38 @@ void TPORecoEvent::accumulateFaserCalPEWithCrosstalk(
     int ix = 0, iy = 0, iz = 0, ilayer = 0;
     if (!decodeFaserCalScintID(channelID, ix, iy, iz, ilayer)) return;
     
-    const double fSide = std::max(0.0, cfg.faserCal_opticalLeakageSide);
-    const double fZ = std::max(0.0, cfg.faserCal_opticalLeakageZ);
-    
+    const double fSideX = std::max(0.0, cfg.faserCal_opticalLeakageSideX);
+    const double fSideY = std::max(0.0, cfg.faserCal_opticalLeakageSideY);
+    const double fSideZ = std::max(0.0, cfg.faserCal_opticalLeakageZ);
+    // ========================================================================
+    // STEP 1: Compute the MEAN PE from the FULL energy deposit at the central
+    // voxel (statistics deliberately NOT applied yet). Leakage to neighbors is
+    // itself a random process (each photon independently ends up in one voxel
+    // or another), so we must NOT take a fixed fraction of an already-sampled
+    // total: that would make every leakage event exactly frac*totalPE, with no
+    // fluctuation of its own. Instead we split the MEAN, then let each target
+    // voxel fluctuate independently around its own (mean-fraction) expectation
+    // in STEP 3 below.
+    // ========================================================================
+    std::array<double, 3> meanFiberPE = {0.0, 0.0, 0.0};
+    const double meanTotalPE = computeFaserCalDirectPE(channelID, energyDepositMeV, meanFiberPE, false);
+
+    if (meanTotalPE <= 0.0) return;
+
+    // ========================================================================
+    // STEP 2: Build redistribution targets.
+    // faserCal_opticalLeakageSideX/Y/Z are the per-axis fractions of PE
+    // leaking to EACH of that axis's two neighbors. Central voxel retains
+    // (1 - 2*fSideX - 2*fSideY - 2*fSideZ).
+    // ========================================================================
+
     struct TargetVoxel {
         long id;
         double frac;
     };
     
     std::vector<TargetVoxel> targets;
-    targets.reserve(7);
+    targets.reserve(5);
     
     double centralFrac = 1.0;
     
@@ -5219,20 +5401,24 @@ void TPORecoEvent::accumulateFaserCalPEWithCrosstalk(
     };
     
     //////////////////////////////////////////////////////////
-	// ADD SIDE NEIGHBORS (4 faces: ±X, ±Y in same layer)
-	// Each neighbor receives 'fSide' fraction of the energy
-	// Light leaks through voxel faces to adjacent scintillator cubes
+	// ADD ±X SIDE NEIGHBORS
+	// Each neighbor receives 'fSideX' fraction of the energy (measured from
+	// data - nonzero despite Mylar, see recoConfig comments).
 	//////////////////////////////////////////////////////////
-    addNeighbor(ix - 1, iy, iz, ilayer, fSide);  // Left face (-X direction)
-    addNeighbor(ix + 1, iy, iz, ilayer, fSide);  // Right face (+X direction)
-    addNeighbor(ix, iy - 1, iz, ilayer, fSide);  // Bottom face (-Y direction)
-    addNeighbor(ix, iy + 1, iz, ilayer, fSide);  // Top face (+Y direction)
+    addNeighbor(ix - 1, iy, iz, ilayer, fSideX);  // Left face (-X direction)
+    addNeighbor(ix + 1, iy, iz, ilayer, fSideX);  // Right face (+X direction)
     //////////////////////////////////////////////////////////
-	// ADD Z NEIGHBORS (optional, currently not implemented)
-    // Would handle light leaking between layers
+	// ADD ±Y NEIGHBORS (same layer)
+	// Each neighbor receives 'fSideY' fraction of the energy (measured from data).
 	//////////////////////////////////////////////////////////
-    //addNeighbor(ix, iy, iz - 1, ilayer, fZ);  // Back face (-Z direction)
-    //addNeighbor(ix, iy, iz + 1, ilayer, fZ);  // Front face (+Z direction)
+    addNeighbor(ix, iy - 1, iz, ilayer, fSideY);  // Bottom face (-Y direction)
+    addNeighbor(ix, iy + 1, iz, ilayer, fSideY);  // Top face (+Y direction)
+    //////////////////////////////////////////////////////////
+	// ADD ±Z NEIGHBORS (within the same layer module)
+	// Each neighbor receives 'fSideZ' fraction of the energy.
+	//////////////////////////////////////////////////////////
+    addNeighbor(ix, iy, iz - 1, ilayer, fSideZ);  // Back face (-Z direction)
+    addNeighbor(ix, iy, iz + 1, ilayer, fSideZ);  // Front face (+Z direction)
 
     if (centralFrac < 0.0) centralFrac = 0.0;
     
@@ -5242,22 +5428,32 @@ void TPORecoEvent::accumulateFaserCalPEWithCrosstalk(
 
     //////////////////////////////////////////////////////////
 	// ACCUMULATE PE FOR EACH TARGET VOXEL
-	// Energy is distributed among voxels according to optical leakage fractions.
-	// For each voxel, convert energy to scintillation photons and then to photoelectrons
-	// Results accumulate in local maps passed as parameters (multiple hits per voxel are summed):
-	//   - voxelPEMap: total PE per voxel (sum of X + Y + Z fibers)
-	//   - voxelPEFibersMap: PE per fiber [X, Y, Z]
-	//
-	// ENERGY CONSERVATION: Total energy distributed = sum of (frac × energyDepositMeV)
-	// With 4 side neighbors: sum of fractions = centralFrac + 4×fSide = 1.0
-	//////////////////////////////////////////////////////////
+	// Distribute the MEAN PE (not energy) to central voxel and neighbors,
+	// then fluctuate each target independently (STEP 3). This preserves
+	// the expectation value (sum of fracs = centralFrac + leakage = 1.0)
+	// while giving each voxel its own statistical draw, rather than a
+	// fixed cut of one already-fluctuated number.
+    //////////////////////////////////////////////////////////
     for (const auto& t : targets) {
-        const double localEnergy = energyDepositMeV * t.frac;
-        if (localEnergy <= 0.0) continue;
-        
-        std::array<double, 3> fiberPE = {0.0, 0.0, 0.0};
-        const double totalPE = computeFaserCalDirectPE(t.id, localEnergy, fiberPE);
-        
+        if (t.frac <= 0.0) continue;
+
+        double peX = meanFiberPE[0] * t.frac;
+        double peY = meanFiberPE[1] * t.frac;
+        double peZ = meanFiberPE[2] * t.frac;
+
+        // ====================================================================
+        // STEP 3: Apply Poisson statistics independently per target voxel and
+        // per fiber direction, around the mean-fraction expectation computed
+        // above. This is what actually makes the leakage fraction "random"
+        // instead of a deterministic mean split.
+        // ====================================================================
+        if (cfg.faserCal_applyPoissonStatistics) {
+            peX = gRandom->Poisson(peX);
+            peY = gRandom->Poisson(peY);
+            peZ = gRandom->Poisson(peZ);
+        }
+        const double pe = peX + peY + peZ;
+
         // Check if this voxel already has PE (multiple hit to same voxel)
         bool isMultipleHit = (voxelPEMap.find(t.id) != voxelPEMap.end());
 		double previousPE = isMultipleHit ? voxelPEMap[t.id] : 0.0;
@@ -5270,30 +5466,30 @@ void TPORecoEvent::accumulateFaserCalPEWithCrosstalk(
 		// 2. Optical leakage from neighboring voxels (fSide × neighbor's energy)
 		// 3. Multiple particles hitting this voxel in the same event
 		//
-		// Example scenario:
-		//   - Particle A hits voxel (5,5,5) with 100 MeV
-		//     → Voxel (6,5,5) receives 3% leakage = 3 MeV → converts to PE → stored
-		//   - Particle B hits voxel (7,5,5) with 200 MeV  
-		//     → Voxel (6,5,5) receives 3% leakage = 6 MeV → converts to PE → ADDED
-		//   - Particle C hits voxel (6,5,5) directly with 50 MeV
-		//     → Voxel (6,5,5) keeps 88% = 44 MeV → converts to PE → ADDED
-		//   Total in voxel (6,5,5): PE from 3 MeV + 6 MeV + 44 MeV
-		//
+		// 
 		// The += operator ensures all contributions are summed correctly!
 		//////////////////////////////////////////////////////////
-        voxelPEMap[t.id] += totalPE;
-        auto& fib = voxelPEFibersMap[t.id];
-        fib[0] += fiberPE[0];  // X fiber PE
-        fib[1] += fiberPE[1];  // Y fiber PE
-        fib[2] += fiberPE[2];  // Z fiber PE
+        voxelPEMap[t.id]          += pe;
+        voxelPEFibersMap[t.id][0] += peX;
+        voxelPEFibersMap[t.id][1] += peY;
+        voxelPEFibersMap[t.id][2] += peZ;
         
         // Debug output for multiple hits to same voxel
 		if (isMultipleHit && verbose > 1) {
 			std::cout << "[DEBUG] Multiple hit to voxel " << t.id 
 				   << ": previous PE=" << previousPE 
-				   << " + new PE=" << totalPE
+				   << " + new PE=" << pe
 				   << " = total PE=" << voxelPEMap[t.id] << std::endl;
 		}
+    }
+    if (verbose > 1) {
+        std::cout << "[DEBUG Crosstalk] channelID=" << channelID
+                  << " meanTotalPE=" << meanTotalPE
+                  << " centralFrac=" << centralFrac
+                  << " nNeighbors=" << (targets.size() - 1) << std::endl;
+        std::cout << "  mean PE_X=" << meanFiberPE[0]
+                  << " mean PE_Y=" << meanFiberPE[1]
+                  << " mean PE_Z=" << meanFiberPE[2] << std::endl;
     }
 }
 
@@ -5315,17 +5511,31 @@ std::vector<TcalEvent::FASERCALVOXELRESPONSE> TPORecoEvent::applyFaserCalDetecto
         std::cout << "  Global fiber capture: " << (recoConfig.faserCal_globalFiberCapture * 100) << "%" << std::endl;
         std::cout << "  Fiber trapping: " << (recoConfig.faserCal_fiberTrappingEfficiency * 100) << "%" << std::endl;
         std::cout << "  SiPM PDE: " << (recoConfig.faserCal_sensorPDE * 100) << "%" << std::endl;
-        std::cout << "  Optical leakage (side): " << (recoConfig.faserCal_opticalLeakageSide * 100) << "% per face" << std::endl;
+        std::cout << "  Optical leakage X: " << (recoConfig.faserCal_opticalLeakageSideX * 100) << "% per face" << std::endl;
+        std::cout << "  Optical leakage Y: " << (recoConfig.faserCal_opticalLeakageSideY * 100) << "% per face" << std::endl;
+        std::cout << "  Optical leakage Z: " << (recoConfig.faserCal_opticalLeakageZ * 100) << "% per face" << std::endl;
         std::cout << "  Poisson statistics: " << (recoConfig.faserCal_applyPoissonStatistics ? "ON" : "OFF") << std::endl;
     }
     
     // Maps to accumulate PE
     std::map<long, double> voxelPEMap;
     std::map<long, std::array<double, 3>> voxelPEFibersMap;
+    std::map<long, double> voxelEnergyMap;  // Total energy deposited per voxel (MeV)
+    
+    // Statistics
+    double totalEnergyDeposited = 0.0;
+    double maxEnergyDeposit = 0.0;
+    long maxEdepHitID = 0;
+    size_t nHitsProcessed = 0;
     
     // Collect energy deposits from all tracks
+    // Note: Multiple particles can legitimately hit the same voxel in one event
+    // We accumulate all their energy deposits
     for (const auto* track : tracks) {
         if (!track) continue;
+        
+        // Track hits within THIS track to avoid duplicates within one track's hit list
+        std::set<std::pair<long, double>> trackHits;
         
         const size_t nhits = std::min(track->fhitIDs.size(), track->fEnergyDeposits.size());
         for (size_t i = 0; i < nhits; ++i) {
@@ -5335,6 +5545,28 @@ std::vector<TcalEvent::FASERCALVOXELRESPONSE> TPORecoEvent::applyFaserCalDetecto
             // Check if this is a FASERCal scintillator hit (hittype == 0)
             const long hittype = hitID / 100000000000LL;
             if (hittype != 0) continue;
+            
+            // Check for duplicate within THIS track's hit list only
+            std::pair<long, double> hitKey = {hitID, edep};
+            if (trackHits.find(hitKey) != trackHits.end()) {
+                if (verbose > 1) {
+                    std::cout << "[WARNING] Duplicate hit within track: hitID=" << hitID 
+                              << ", edep=" << edep << " MeV (skipping)" << std::endl;
+                }
+                continue;  // Skip duplicate within same track
+            }
+            trackHits.insert(hitKey);
+            
+            // Track total energy deposited per voxel
+            voxelEnergyMap[hitID] += edep;
+            
+            // Track statistics
+            totalEnergyDeposited += edep;
+            nHitsProcessed++;
+            if (edep > maxEnergyDeposit) {
+                maxEnergyDeposit = edep;
+                maxEdepHitID = hitID;
+            }
             
             // Apply detector response with optical cross talk
             accumulateFaserCalPEWithCrosstalk(voxelPEMap, voxelPEFibersMap, hitID, edep);
@@ -5353,21 +5585,58 @@ std::vector<TcalEvent::FASERCALVOXELRESPONSE> TPORecoEvent::applyFaserCalDetecto
         resp.nPEFiber1Direct = fibers[1];
         resp.nPEFiber2Direct = fibers[2];
         
+        // Add total energy deposited in this voxel
+        auto energyIt = voxelEnergyMap.find(kv.first);
+        resp.totalEnergyDeposit = (energyIt != voxelEnergyMap.end()) ? energyIt->second : 0.0;
+        
         result.push_back(resp);
     }
     
     if (verbose > 0) {
+        std::cout << "[FASERCal DetectorResponse] Energy statistics:" << std::endl;
+        std::cout << "  Hits processed: " << nHitsProcessed << std::endl;
+        std::cout << "  Total energy deposited: " << totalEnergyDeposited << " MeV";
+        if (totalEnergyDeposited > 1000.0) {
+            std::cout << " (" << (totalEnergyDeposited/1000.0) << " GeV)";
+        }
+        std::cout << std::endl;
+        std::cout << "  Average energy/hit: " << (nHitsProcessed > 0 ? totalEnergyDeposited/nHitsProcessed : 0.0) << " MeV" << std::endl;
+        std::cout << "  Max energy deposit: " << maxEnergyDeposit << " MeV (hitID=" << maxEdepHitID << ")" << std::endl;
+        
         std::cout << "[FASERCal DetectorResponse] Generated " << result.size() << " voxel responses" << std::endl;
         if (!result.empty()) {
             double totalPE = 0.0;
             double maxPE = 0.0;
+            double maxVoxelEnergy = 0.0;
+            long maxPE_channelID = 0;
+            long maxEnergy_channelID = 0;
+            
             for (const auto& r : result) {
                 totalPE += r.nPE;
-                maxPE = std::max(maxPE, r.nPE);
+                if (r.nPE > maxPE) {
+                    maxPE = r.nPE;
+                    maxPE_channelID = r.channelID;
+                }
+                if (r.totalEnergyDeposit > maxVoxelEnergy) {
+                    maxVoxelEnergy = r.totalEnergyDeposit;
+                    maxEnergy_channelID = r.channelID;
+                }
             }
+            
             std::cout << "  Total PE: " << totalPE << std::endl;
             std::cout << "  Average PE/voxel: " << (totalPE / result.size()) << std::endl;
-            std::cout << "  Max PE in single voxel: " << maxPE << std::endl;
+            std::cout << "  Max PE in single voxel: " << maxPE << " (channelID=" << maxPE_channelID << ")" << std::endl;
+            std::cout << "  Max total energy per voxel: " << maxVoxelEnergy << " MeV (channelID=" << maxEnergy_channelID << ")" << std::endl;
+            std::cout << "  Overall PE/MeV conversion: " << (totalEnergyDeposited > 0 ? totalPE/totalEnergyDeposited : 0.0) << " PE/MeV" << std::endl;
+            
+            // Find the voxel with max PE and show its energy
+            for (const auto& r : result) {
+                if (r.channelID == maxPE_channelID) {
+                    std::cout << "  Voxel with max PE: Energy=" << r.totalEnergyDeposit << " MeV, PE=" << r.nPE 
+                              << ", PE/MeV=" << (r.totalEnergyDeposit > 0 ? r.nPE/r.totalEnergyDeposit : 0.0) << std::endl;
+                    break;
+                }
+            }
         }
     }
     
@@ -5411,4 +5680,333 @@ void TPORecoEvent::ApplyFaserCalDetectorResponse() {
         std::cout << "  Stored " << voxelResponses.size() << " voxel responses in TPORecoEvent" << std::endl;
         std::cout << "========================================\n" << std::endl;
     }
+    
+    // Automatically compute fiber channel distributions
+    ComputeFaserCalFiberChannels();
+}
+
+//////////////////////////////////////////////////////////
+// COMPUTE FIBER CHANNEL PE DISTRIBUTIONS
+// Aggregates light from all voxels along each fiber
+//////////////////////////////////////////////////////////
+
+void TPORecoEvent::ComputeFaserCalFiberChannels() {
+    // Clear previous results
+    faserCalFiberChannelsX.clear();
+    faserCalFiberChannelsY.clear();
+    faserCalFiberChannelsZ.clear();
+    
+    if (faserCalVoxelResponse.empty()) {
+        if (verbose > 0) {
+            std::cout << "[ComputeFaserCalFiberChannels] No voxel responses available. "
+                      << "Call ApplyFaserCalDetectorResponse() first." << std::endl;
+        }
+        return;
+    }
+    
+    if (verbose > 0) {
+        std::cout << "\n========================================" << std::endl;
+        std::cout << "Computing Fiber Channel PE Distributions" << std::endl;
+        std::cout << "========================================" << std::endl;
+    }
+    
+    // Maps to accumulate PE per fiber channel
+    // X-fibers: key = (iy, iz), each fiber runs through all ix at fixed (iy, iz)
+    // Y-fibers: key = (ix, iz), each fiber runs through all iy at fixed (ix, iz)
+    // Z-fibers: key = (ix, iy, ilayer), each fiber runs through all iz at fixed (ix, iy, ilayer)
+    std::map<std::pair<int, int>, double> fiberPE_X;
+    std::map<std::pair<int, int>, double> fiberPE_Y;
+    std::map<std::tuple<int, int, int>, double> fiberPE_Z;
+    
+    std::map<std::pair<int, int>, int> fiberHits_X;
+    std::map<std::pair<int, int>, int> fiberHits_Y;
+    std::map<std::tuple<int, int, int>, int> fiberHits_Z;
+    
+    // Process each voxel response
+    for (const auto& voxel : faserCalVoxelResponse) {
+        int ix, iy, iz, ilayer;
+        if (!decodeFaserCalScintID(voxel.channelID, ix, iy, iz, ilayer)) {
+            continue;
+        }
+        
+        // X-fiber: runs along X direction, identified by (Y, Z) position
+        // This fiber collects light from voxels (0,iy,iz), (1,iy,iz), ..., (110,iy,iz)
+        std::pair<int, int> keyX = {iy, iz + ilayer * 48}; // Use global Z index
+        fiberPE_X[keyX] += voxel.nPEFiber0Direct;
+        fiberHits_X[keyX]++;
+        
+        // Y-fiber: runs along Y direction, identified by (X, Z) position
+        // This fiber collects light from voxels (ix,0,iz), (ix,1,iz), ..., (ix,47,iz)
+        std::pair<int, int> keyY = {ix, iz + ilayer * 48}; // Use global Z index
+        fiberPE_Y[keyY] += voxel.nPEFiber1Direct;
+        fiberHits_Y[keyY]++;
+        
+        // Z-fiber: runs along Z direction within layer, identified by (X, Y, layer)
+        // This fiber collects light from voxels (ix,iy,0), (ix,iy,1), ..., (ix,iy,47) in layer
+        std::tuple<int, int, int> keyZ = {ix, iy, ilayer};
+        fiberPE_Z[keyZ] += voxel.nPEFiber2Direct;
+        fiberHits_Z[keyZ]++;
+    }
+    
+    // Electronic noise / resolution smearing, applied once per aggregated
+    // SiPM channel (not per voxel) - see recoConfig.faserCal_electronicNoiseSigma{X,Y,Z}
+    const auto& cfg = recoConfig;
+    auto applyElectronicNoise = [&cfg](double pe, double sigma) -> double {
+        if (!cfg.faserCal_applyElectronicNoise || sigma <= 0.0) return pe;
+        return std::max(0.0, pe + gRandom->Gaus(0.0, sigma));
+    };
+
+    // Convert maps to vectors with proper structure
+    int channelID = 0;
+    for (const auto& [key, pe] : fiberPE_X) {
+        FIBERCHANNEL ch;
+        ch.channel_id = channelID++;
+        ch.coord1 = key.first;   // Y
+        ch.coord2 = key.second;  // Z (global)
+        ch.layer = -1;
+        ch.totalPE = applyElectronicNoise(pe, cfg.faserCal_electronicNoiseSigmaX);
+        ch.nVoxelsHit = fiberHits_X[key];
+        faserCalFiberChannelsX.push_back(ch);
+    }
+
+    channelID = 0;
+    for (const auto& [key, pe] : fiberPE_Y) {
+        FIBERCHANNEL ch;
+        ch.channel_id = channelID++;
+        ch.coord1 = key.first;   // X
+        ch.coord2 = key.second;  // Z (global)
+        ch.layer = -1;
+        ch.totalPE = applyElectronicNoise(pe, cfg.faserCal_electronicNoiseSigmaY);
+        ch.nVoxelsHit = fiberHits_Y[key];
+        faserCalFiberChannelsY.push_back(ch);
+    }
+
+    channelID = 0;
+    for (const auto& [key, pe] : fiberPE_Z) {
+        FIBERCHANNEL ch;
+        ch.channel_id = channelID++;
+        ch.coord1 = std::get<0>(key);  // X
+        ch.coord2 = std::get<1>(key);  // Y
+        ch.layer = std::get<2>(key);   // layer
+        ch.totalPE = applyElectronicNoise(pe, cfg.faserCal_electronicNoiseSigmaZ);
+        ch.nVoxelsHit = fiberHits_Z[key];
+        faserCalFiberChannelsZ.push_back(ch);
+    }
+    
+    if (verbose > 0) {
+        std::cout << "  X-fibers (run along X, readout at +X): " << faserCalFiberChannelsX.size() << " channels" << std::endl;
+        std::cout << "  Y-fibers (run along Y, readout at +Y): " << faserCalFiberChannelsY.size() << " channels" << std::endl;
+        std::cout << "  Z-fibers (run along Z, readout at +Z): " << faserCalFiberChannelsZ.size() << " channels" << std::endl;
+        
+        double totalPE_X = 0, totalPE_Y = 0, totalPE_Z = 0;
+        for (const auto& ch : faserCalFiberChannelsX) totalPE_X += ch.totalPE;
+        for (const auto& ch : faserCalFiberChannelsY) totalPE_Y += ch.totalPE;
+        for (const auto& ch : faserCalFiberChannelsZ) totalPE_Z += ch.totalPE;
+        
+        std::cout << "  Total PE collected:" << std::endl;
+        std::cout << "    X-fibers: " << totalPE_X << " PE" << std::endl;
+        std::cout << "    Y-fibers: " << totalPE_Y << " PE" << std::endl;
+        std::cout << "    Z-fibers: " << totalPE_Z << " PE" << std::endl;
+        std::cout << "========================================\n" << std::endl;
+    }
+}
+
+//////////////////////////////////////////////////////////
+// DUMP FIBER CHANNEL PE DISTRIBUTIONS
+//////////////////////////////////////////////////////////
+
+void TPORecoEvent::DumpFaserCalFiberChannels(int maxChannels, bool sortByPE) {
+    std::cout << "\n========================================" << std::endl;
+    std::cout << "FASERCal Fiber Channel PE Distributions" << std::endl;
+    std::cout << "========================================" << std::endl;
+    
+    if (faserCalFiberChannelsX.empty() && faserCalFiberChannelsY.empty() && faserCalFiberChannelsZ.empty()) {
+        std::cout << "No fiber channel data available. Call ComputeFaserCalFiberChannels() first." << std::endl;
+        std::cout << "========================================\n" << std::endl;
+        return;
+    }
+    
+    auto dumpChannels = [&](const std::vector<FIBERCHANNEL>& channels, 
+                            const std::string& fiberType,
+                            const std::string& coord1Name,
+                            const std::string& coord2Name) {
+        if (channels.empty()) {
+            std::cout << "\n" << fiberType << ": No channels with signal" << std::endl;
+            return;
+        }
+        
+        // Copy and optionally sort
+        auto sortedChannels = channels;
+        if (sortByPE) {
+            std::sort(sortedChannels.begin(), sortedChannels.end(),
+                     [](const FIBERCHANNEL& a, const FIBERCHANNEL& b) {
+                         return a.totalPE > b.totalPE;
+                     });
+        }
+        
+        // Statistics
+        double totalPE = 0, maxPE = 0, minPE = 1e9;
+        int totalVoxelsHit = 0;
+        for (const auto& ch : sortedChannels) {
+            totalPE += ch.totalPE;
+            totalVoxelsHit += ch.nVoxelsHit;
+            maxPE = std::max(maxPE, ch.totalPE);
+            if (ch.totalPE > 0) minPE = std::min(minPE, ch.totalPE);
+        }
+        double avgPE = totalPE / sortedChannels.size();
+        
+        std::cout << "\n" << fiberType << " (" << sortedChannels.size() << " channels with signal)" << std::endl;
+        std::cout << "  Total PE: " << totalPE << std::endl;
+        std::cout << "  Average PE/channel: " << avgPE << std::endl;
+        std::cout << "  Max PE: " << maxPE << std::endl;
+        std::cout << "  Min PE: " << (minPE < 1e9 ? minPE : 0.0) << std::endl;
+        std::cout << "  Total voxels hit: " << totalVoxelsHit << std::endl;
+        
+        int nToPrint = (maxChannels > 0) ? std::min(maxChannels, (int)sortedChannels.size()) 
+                                         : sortedChannels.size();
+        
+        std::cout << "\n  " << std::left << std::setw(10) << "Channel"
+                  << std::setw(12) << coord1Name
+                  << std::setw(12) << coord2Name;
+        if (fiberType.find("Z-fiber") != std::string::npos) {
+            std::cout << std::setw(10) << "Layer";
+        }
+        std::cout << std::setw(15) << "Total PE"
+                  << std::setw(12) << "Voxels Hit" << std::endl;
+        std::cout << "  " << std::string(60, '-') << std::endl;
+        
+        for (int i = 0; i < nToPrint; ++i) {
+            const auto& ch = sortedChannels[i];
+            std::cout << "  " << std::left << std::setw(10) << ch.channel_id
+                      << std::setw(12) << ch.coord1
+                      << std::setw(12) << ch.coord2;
+            if (fiberType.find("Z-fiber") != std::string::npos) {
+                std::cout << std::setw(10) << ch.layer;
+            }
+            std::cout << std::setw(15) << std::fixed << std::setprecision(2) << ch.totalPE
+                      << std::setw(12) << ch.nVoxelsHit << std::endl;
+        }
+        
+        if (nToPrint < (int)sortedChannels.size()) {
+            std::cout << "  ... (" << (sortedChannels.size() - nToPrint) << " more channels)" << std::endl;
+        }
+    };
+    
+    dumpChannels(faserCalFiberChannelsX, "X-fibers (along X, readout +X)", "Y", "Z_global");
+    dumpChannels(faserCalFiberChannelsY, "Y-fibers (along Y, readout +Y)", "X", "Z_global");
+    dumpChannels(faserCalFiberChannelsZ, "Z-fibers (along Z, readout +Z)", "X", "Y");
+    
+    std::cout << "\n========================================\n" << std::endl;
+}
+
+//////////////////////////////////////////////////////////
+// CREATE HISTOGRAMS OF FIBER CHANNEL PE DISTRIBUTIONS
+//////////////////////////////////////////////////////////
+
+std::map<std::string, TH1*> TPORecoEvent::PlotFaserCalFiberChannels(const std::string& prefix) {
+    std::map<std::string, TH1*> histograms;
+    
+    if (faserCalFiberChannelsX.empty() && faserCalFiberChannelsY.empty() && faserCalFiberChannelsZ.empty()) {
+        std::cerr << "[PlotFaserCalFiberChannels] No fiber channel data available. "
+                  << "Call ComputeFaserCalFiberChannels() first." << std::endl;
+        return histograms;
+    }
+    
+    // Determine PE ranges for histograms
+    double maxPE_X = 0, maxPE_Y = 0, maxPE_Z = 0;
+    for (const auto& ch : faserCalFiberChannelsX) maxPE_X = std::max(maxPE_X, ch.totalPE);
+    for (const auto& ch : faserCalFiberChannelsY) maxPE_Y = std::max(maxPE_Y, ch.totalPE);
+    for (const auto& ch : faserCalFiberChannelsZ) maxPE_Z = std::max(maxPE_Z, ch.totalPE);
+    
+    double maxPE_all = std::max({maxPE_X, maxPE_Y, maxPE_Z});
+    int nbins_PE = std::min(200, std::max(50, (int)(maxPE_all / 10)));
+    
+    // 1D histograms: PE distribution per channel
+    TH1D* h_X_PE = new TH1D((prefix + "_X_PE").c_str(), 
+                            "X-fibers: PE per channel;PE;Channels", 
+                            nbins_PE, 0, maxPE_all * 1.1);
+    TH1D* h_Y_PE = new TH1D((prefix + "_Y_PE").c_str(), 
+                            "Y-fibers: PE per channel;PE;Channels", 
+                            nbins_PE, 0, maxPE_all * 1.1);
+    TH1D* h_Z_PE = new TH1D((prefix + "_Z_PE").c_str(), 
+                            "Z-fibers: PE per channel;PE;Channels", 
+                            nbins_PE, 0, maxPE_all * 1.1);
+    
+    for (const auto& ch : faserCalFiberChannelsX) h_X_PE->Fill(ch.totalPE);
+    for (const auto& ch : faserCalFiberChannelsY) h_Y_PE->Fill(ch.totalPE);
+    for (const auto& ch : faserCalFiberChannelsZ) h_Z_PE->Fill(ch.totalPE);
+    
+    histograms["X_PE"] = h_X_PE;
+    histograms["Y_PE"] = h_Y_PE;
+    histograms["Z_PE"] = h_Z_PE;
+    
+    // 1D histograms: Number of voxels hit per channel
+    TH1D* h_X_nHits = new TH1D((prefix + "_X_nHits").c_str(), 
+                               "X-fibers: Voxels hit per channel;N voxels;Channels", 
+                               120, 0, 120);
+    TH1D* h_Y_nHits = new TH1D((prefix + "_Y_nHits").c_str(), 
+                               "Y-fibers: Voxels hit per channel;N voxels;Channels", 
+                               50, 0, 50);
+    TH1D* h_Z_nHits = new TH1D((prefix + "_Z_nHits").c_str(), 
+                               "Z-fibers: Voxels hit per channel;N voxels;Channels", 
+                               50, 0, 50);
+    
+    for (const auto& ch : faserCalFiberChannelsX) h_X_nHits->Fill(ch.nVoxelsHit);
+    for (const auto& ch : faserCalFiberChannelsY) h_Y_nHits->Fill(ch.nVoxelsHit);
+    for (const auto& ch : faserCalFiberChannelsZ) h_Z_nHits->Fill(ch.nVoxelsHit);
+    
+    histograms["X_nHits"] = h_X_nHits;
+    histograms["Y_nHits"] = h_Y_nHits;
+    histograms["Z_nHits"] = h_Z_nHits;
+    
+    // 2D histograms: Spatial distribution of PE
+    histograms["X_2D"] = CreateFiberPEMap(0, prefix + "_X_map", 
+                                          "X-fibers PE map;Y (voxel);Z (voxel);PE");
+    histograms["Y_2D"] = CreateFiberPEMap(1, prefix + "_Y_map", 
+                                          "Y-fibers PE map;X (voxel);Z (voxel);PE");
+    histograms["Z_2D"] = CreateFiberPEMap(2, prefix + "_Z_map", 
+                                          "Z-fibers PE map (all layers);X (voxel);Y (voxel);PE");
+    
+    if (verbose > 0) {
+        std::cout << "[PlotFaserCalFiberChannels] Created " << histograms.size() 
+                  << " histograms with prefix '" << prefix << "'" << std::endl;
+    }
+    
+    return histograms;
+}
+
+//////////////////////////////////////////////////////////
+// CREATE 2D MAP OF FIBER PE
+//////////////////////////////////////////////////////////
+
+TH2D* TPORecoEvent::CreateFiberPEMap(int direction, const std::string& name, const std::string& title) {
+    const auto& g = geom_detector;
+    const int nx = static_cast<int>(g.fScintillatorSizeX / g.fScintillatorVoxelSize);  // 11
+    const int ny = static_cast<int>(g.fScintillatorSizeY / g.fScintillatorVoxelSize);  // 48
+    const int nz_per_layer = std::max(1, static_cast<int>(g.fSandwichLength / g.fScintillatorVoxelSize));  // 48
+    const int total_z = nz_per_layer * g.NRep;  // Total Z voxels across all layers
+    
+    TH2D* hist = nullptr;
+    
+    if (direction == 0) {
+        // X-fibers: map PE as function of (Y, Z)
+        hist = new TH2D(name.c_str(), title.c_str(), ny, 0, ny, total_z, 0, total_z);
+        for (const auto& ch : faserCalFiberChannelsX) {
+            hist->Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+        }
+    } else if (direction == 1) {
+        // Y-fibers: map PE as function of (X, Z)
+        hist = new TH2D(name.c_str(), title.c_str(), nx, 0, nx, total_z, 0, total_z);
+        for (const auto& ch : faserCalFiberChannelsY) {
+            hist->Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+        }
+    } else if (direction == 2) {
+        // Z-fibers: map PE as function of (X, Y), summed over all layers
+        hist = new TH2D(name.c_str(), title.c_str(), nx, 0, nx, ny, 0, ny);
+        for (const auto& ch : faserCalFiberChannelsZ) {
+            hist->Fill(ch.coord1 + 0.5, ch.coord2 + 0.5, ch.totalPE);
+        }
+    }
+    
+    return hist;
 }

--- a/CoreUtils/TPORecoEvent.hh
+++ b/CoreUtils/TPORecoEvent.hh
@@ -77,41 +77,66 @@ private:
 
     //////////////////////////////////////////////////////////
     // FASERCAL DETECTOR RESPONSE FUNCTIONS
-    // Convert energy deposits to photoelectrons
-    // Moved from Geant4 to reconstruction level
+    // Convert energy deposits to photoelectrons (PE)
+    // 
+    // Fiber geometry: 11×48×48 voxels per layer
+    // - Each voxel contributes light to 3 fibers (X, Y, Z directions)
+    // - Fibers run line-by-line through voxels collecting light
+    // - All fibers read out at positive (+) end with SiPMs
+    // - Light attenuates with distance along fiber to readout
     //////////////////////////////////////////////////////////
     
     /// @brief Apply FASERCal detector response to convert energy deposits to PE
+    /// @details Processes all tracks and voxel hits, computing PE for X/Y/Z fibers.
+    ///          Includes optical crosstalk between neighboring voxels.
     /// @param tracks Input digitized tracks with energy deposits
-    /// @return Vector of voxel PE responses
+    /// @return Vector of voxel PE responses (one per voxel with signal)
     std::vector<TcalEvent::FASERCALVOXELRESPONSE> applyFaserCalDetectorResponse(
         const std::vector<DigitizedTrack*>& tracks);
     
     /// @brief Compute PE for a single voxel from energy deposit
-    /// @param channelID Voxel channel ID
+    /// @details Calculates light propagation from voxel to SiPM readout at +X, +Y, +Z ends.
+    ///          Uses dual-component attenuation model (bulk + Rayleigh scattering).
+    /// @param channelID Voxel channel ID (encoded ix, iy, iz, ilayer)
     /// @param energyDepositMeV Energy deposited in MeV
-    /// @param fiberPE Output array for X,Y,Z fiber PE
-    /// @return Total PE (sum of all fibers)
-    double computeFaserCalDirectPE(long channelID, double energyDepositMeV, 
-                                   std::array<double, 3>& fiberPE);
+    /// @param fiberPE Output array for X,Y,Z fiber PE [out]
+    /// @param applyStatistics If true (default), apply Poisson fluctuations (per
+    ///        recoConfig.faserCal_applyPoissonStatistics) before returning. Pass
+    ///        false to get the raw mean PE, e.g. when the caller needs to split
+    ///        the mean across several voxels (crosstalk) before fluctuating each
+    ///        target independently.
+    /// @return Total PE (sum of all three fibers)
+    double computeFaserCalDirectPE(long channelID, double energyDepositMeV,
+                                   std::array<double, 3>& fiberPE,
+                                   bool applyStatistics = true);
     
     /// @brief Apply optical leakage and accumulate PE with crosstalk
-    /// @param voxelPEMap Map to accumulate total PE per voxel
-    /// @param voxelPEFibersMap Map to accumulate PE per fiber direction
+    /// @details Light can leak through voxel faces to neighbors (1% per face).
+    ///          Voxels without direct hits can still receive PE from neighbors.
+    /// @param voxelPEMap Map to accumulate total PE per voxel [in/out]
+    /// @param voxelPEFibersMap Map to accumulate PE per fiber direction [in/out]
     /// @param channelID Central voxel ID where energy was deposited
-    /// @param energyDepositMeV Energy deposited in central voxel
+    /// @param energyDepositMeV Energy deposited in central voxel (MeV)
     void accumulateFaserCalPEWithCrosstalk(
         std::map<long, double>& voxelPEMap,
         std::map<long, std::array<double, 3>>& voxelPEFibersMap,
         long channelID, double energyDepositMeV);
     
     /// @brief Helper function to decode FASERCal voxel ID
+    /// @param id Encoded channel ID
+    /// @param ix X voxel index [out]
+    /// @param iy Y voxel index [out]
+    /// @param iz Z voxel index within layer [out]
+    /// @param ilayer Layer/module index [out]
+    /// @return true if valid scintillator ID (hittype==0)
     bool decodeFaserCalScintID(long id, int& ix, int& iy, int& iz, int& ilayer);
     
     /// @brief Helper function to encode FASERCal voxel ID
+    /// @return Encoded channel ID
     long encodeFaserCalScintID(int ix, int iy, int iz, int ilayer);
     
     /// @brief Helper function to check if voxel indices are valid
+    /// @return true if indices within detector bounds
     bool isValidFaserCalVoxelIndex(int ix, int iy, int iz, int ilayer);
 
     /// @brief The vector that holds all the PORec (Reconstructed POs) in the event
@@ -233,6 +258,19 @@ public:
     // FASERCal detector response (PE values per voxel)
     std::vector<TcalEvent::FASERCALVOXELRESPONSE> faserCalVoxelResponse;
 
+    /// @brief FASERCal fiber channel PE distributions (what each SiPM sees)
+    /// Each fiber collects light from all voxels along its path
+    struct FIBERCHANNEL {
+        int channel_id;      // Unique channel identifier
+        int coord1, coord2;  // Position indices (Y,Z for X-fiber; X,Z for Y-fiber; X,Y for Z-fiber)
+        int layer;           // Layer index (relevant for Z-fibers)
+        double totalPE;      // Total PE collected by this fiber (sum from all voxels)
+        int nVoxelsHit;      // Number of voxels along this fiber with energy deposits
+    };
+    std::vector<FIBERCHANNEL> faserCalFiberChannelsX;  // X-fibers: indexed by (Y, Z) - SAVED TO ROOT
+    std::vector<FIBERCHANNEL> faserCalFiberChannelsY;  // Y-fibers: indexed by (X, Z) - SAVED TO ROOT  
+    std::vector<FIBERCHANNEL> faserCalFiberChannelsZ;  // Z-fibers: indexed by (X, Y, layer) - SAVED TO ROOT
+    
     // @brief A copy of the geometry originally stored in TCalEvent
     struct TcalEvent::GEOM_DETECTOR geom_detector;
 
@@ -306,6 +344,14 @@ public:
         //////////////////////////////////////////////////////////
         // FASERCAL DETECTOR RESPONSE CONFIGURATION
         // Parameters for converting energy deposits to photoelectrons
+        // 
+        // FIBER GEOMETRY (11 x 48 x 48 voxels per layer):
+        // - X-fibers: 48×48 fibers running along X (11 voxels/fiber), readout at +X
+        // - Y-fibers: 11×48 fibers running along Y (48 voxels/fiber), readout at +Y  
+        // - Z-fibers: 11×48 fibers running along Z (48 voxels/fiber per layer), readout at +Z
+        // 
+        // Each voxel contributes light to 3 fibers (one in each direction).
+        // Light propagates along fiber to SiPM at positive (+) end with attenuation.
         //////////////////////////////////////////////////////////
         
         // Scintillation and light collection
@@ -314,23 +360,72 @@ public:
         double faserCal_fiberTrappingEfficiency = 0.05;   // 5% trapping in fiber
         double faserCal_sensorPDE = 0.25;                 // 25% SiPM photon detection efficiency
         
-        // Attenuation lengths for each fiber direction (mm)
-        double faserCal_fiberAttenuationLengthX = 3000.0;
-        double faserCal_fiberAttenuationLengthY = 3000.0;
-        double faserCal_fiberAttenuationLengthZ = 3000.0;
+        // Dual-component attenuation model for each fiber direction (mm)
+        // Model: Attenuation = f_short * exp(-d/L_short) + (1-f_short) * exp(-d/L_long)
+        // Short component: fast attenuation (bulk absorption, defects)
+        // Long component: slow attenuation (Rayleigh scattering, high-quality transmission)
         
-        // Readout configuration (which end of detector has SiPM readout)
-        bool faserCal_readoutAtPositiveX = true;
-        bool faserCal_readoutAtPositiveY = true;
-        bool faserCal_readoutAtPositiveZ = true;
+        // Short attenuation lengths (from SuperFGD) https://arxiv.org/html/2603.14921v1
+        double faserCal_fiberAttenuationLengthShortX = 350.0; // in mm
+        double faserCal_fiberAttenuationLengthShortY = 350.0;
+        double faserCal_fiberAttenuationLengthShortZ = 430.0;
         
-        // Optical crosstalk between neighboring voxels
-        double faserCal_opticalLeakageSide = 0.03;  // 3% to each side neighbor (±X, ±Y)
-        double faserCal_opticalLeakageZ = 0.0;      // leakage to ±Z neighbors (not implemented)
+        // Long attenuation lengths (from SuperFGD) https://arxiv.org/html/2603.14921v1
+        double faserCal_fiberAttenuationLengthLongX = 4000.0; // in mm
+        double faserCal_fiberAttenuationLengthLongY = 4000.0;
+        double faserCal_fiberAttenuationLengthLongZ = 5000.0;
+        
+        // Fraction of light in short component (typically 0.2-0.4) https://arxiv.org/html/2603.14921v1
+        double faserCal_fiberShortComponentFractionX = 0.29;
+        double faserCal_fiberShortComponentFractionY = 0.29;
+        double faserCal_fiberShortComponentFractionZ = 0.33;
+        
+        // Optical crosstalk between neighboring voxels, measured from data as
+        // XT_face = sum(light leakage hits in that neighbor) / sum(light yield
+        // in the central/seed cube), separately for the 4 transverse-plane
+        // neighbors (x+1, x-1, y+1, y-1). VALUES ARE IN PERCENT:
+        //   XT y+1 = 0.2660%, XT y-1 = 0.2784%, XT x+1 = 0.2818%, XT x-1 = 0.2398%
+        // Despite Mylar foils, data shows nonzero crosstalk in X too (contrary
+        // to the original "no leakage in X" prototype assumption), at a level
+        // similar to Y. NOTE: the data ratio is likely an UNDERESTIMATE - the
+        // 1 p.e. detection threshold suppresses low-PE leakage counts, so the
+        // true crosstalk may be somewhat higher.
+        //
+        // These are RATIOS to the central signal (PE_neighbor / PE_central), not
+        // fractions of a shared total (the 4 ratios sum to ~1.07%). They are
+        // converted to model fractions (frac_face, used directly in addNeighbor
+        // below) via: frac_face = ratio_face * (1 - S), S = R/(1+R), where R is
+        // the sum of the 4 ratios (as fractions, i.e. divided by 100). Solving
+        // gives centralFrac ~= 0.989 (~98.9% of light stays in the seed cube,
+        // ~1.1% leaks out total), and per-face fractions ~0.24%-0.28%.
+        // faserCal_opticalLeakageSideX/Y below are set to the per-axis AVERAGE
+        // of the +/- fractions (the code applies one value to both +/-
+        // neighbors on a given axis).
+        //
+        // faserCal_opticalLeakageZ is for the ±iz neighbors (in-layer,
+        // along-fiber depth) - a different axis, NOT covered by the
+        // transverse-plane crosstalk study above (no direct data). Rather than
+        // the old ad hoc 1% guess, it is set to the same order of magnitude as
+        // the measured X/Y values (average of SideX, SideY) as a placeholder
+        // until Z crosstalk is measured directly.
+        double faserCal_opticalLeakageSideX = 0.00258;  // leakage to ±X neighbors (avg of x+1=0.279%, x-1=0.237%)
+        double faserCal_opticalLeakageSideY = 0.00269;  // leakage to ±Y neighbors (avg of y+1=0.263%, y-1=0.276%)
+        double faserCal_opticalLeakageZ = 0.00264;       // leakage to ±Z (in-layer fiber-depth) neighbors - placeholder = avg(SideX, SideY), not yet measured directly
         
         // Statistical fluctuations
         bool faserCal_applyPoissonStatistics = true;  // Apply Poisson fluctuations to PE
-        
+
+        // Electronic noise / resolution at the SiPM channel level.
+        // From data/MC comparison of the 2D view PE spectra: the width of the
+        // Gaussian peak in data exceeds MC by these amounts (in PE), attributed
+        // to SiPM+electronics noise not modeled by Poisson photon statistics alone.
+        // Applied once per aggregated fiber channel (not per voxel), added in
+        // quadrature-equivalent as an independent zero-mean Gaussian smearing.
+        bool faserCal_applyElectronicNoise = true;
+        double faserCal_electronicNoiseSigmaX = 5.11;  // PE, from XZ view data/MC comparison
+        double faserCal_electronicNoiseSigmaY = 6.24;  // PE, from YZ view data/MC comparison
+        double faserCal_electronicNoiseSigmaZ = 0.0;   // PE, not yet measured
+
         // Enable/disable detector response (set false to use energy deposits directly)
         bool faserCal_applyDetectorResponse = true;
 
@@ -380,6 +475,29 @@ public:
     /// Results are stored in faserCalVoxelResponse member variable
     void ApplyFaserCalDetectorResponse();
 
+    /// @brief Compute fiber channel PE distributions from voxel responses
+    /// @details Aggregates PE from all voxels along each fiber to show what each SiPM sees.
+    ///          Must be called after ApplyFaserCalDetectorResponse().
+    ///          Results stored in faserCalFiberChannelsX/Y/Z member variables.
+    void ComputeFaserCalFiberChannels();
+
+    /// @brief Dump FASERCal fiber channel PE distributions
+    /// @param maxChannels Maximum number of channels to print per direction (0=all)
+    /// @param sortByPE If true, sort channels by PE (highest first)
+    void DumpFaserCalFiberChannels(int maxChannels = 50, bool sortByPE = true);
+
+    /// @brief Create histograms of fiber channel PE distributions
+    /// @param prefix Histogram name prefix (default: "h_fiber")
+    /// @return Map of histogram pointers: "X_PE", "Y_PE", "Z_PE", "X_2D", "Y_2D", "Z_2D"
+    std::map<std::string, TH1*> PlotFaserCalFiberChannels(const std::string& prefix = "h_fiber");
+
+    /// @brief Create 2D map of fiber PE for a given direction
+    /// @param direction 0=X-fibers, 1=Y-fibers, 2=Z-fibers
+    /// @param name Histogram name
+    /// @param title Histogram title
+    /// @return TH2D showing PE distribution in detector coordinates
+    TH2D* CreateFiberPEMap(int direction, const std::string& name, const std::string& title);
+
     /// @brief Reconstruct the muon spectrometer's tracks
     void ReconstructMuonSpectrometer(); // added by Umut
     void ReconstructMuonSpectrometer_obs(); 
@@ -427,7 +545,7 @@ public:
 
 
 
-    ClassDef(TPORecoEvent,3)
+    ClassDef(TPORecoEvent,4)
 };
 
 #endif

--- a/CoreUtils/TcalEvent.cc
+++ b/CoreUtils/TcalEvent.cc
@@ -259,55 +259,60 @@ int TcalEvent::Load_event(std::string base_path, int run_number, int ievent,
     m_rootFile -> Close();
     delete m_rootFile;
 
-    // check geometry
-        const char *volumeName = "ContainerLogical";
-    TGeoVolume *targetVolume = gGeoManager->GetVolume(volumeName);
-
-    if (targetVolume)
+    // check geometry — search for the FASERCal container volume by name prefix
+    // (ROOT 6.36+ preserves GDML hex-address suffixes like "ContainerLogical0xb85090",
+    //  so GetVolume("ContainerLogical") may not find it; iterate instead)
     {
-        //std::cout << "Found volume: " << targetVolume->GetName() << std::endl;
-        // You can now draw it, modify it, or use it for positioning
-        // targetVolume->Draw();
-        // check its dimensions
-        Double_t dims[3] = {0.0, 0.0, 0.0};
-        TGeoShape *shape = targetVolume->GetShape();
-        if (shape) {
-            // If it's a box, use the typed accessors (ROOT shapes are in cm)
-            TGeoBBox *bbox = dynamic_cast<TGeoBBox*>(shape);
-            if (bbox) {
-                // GetDx/GetDy/GetDz return half-lengths in cm -> convert to mm and full length
-                dims[0] = 2.0 * bbox->GetDX() * 10.0; // X in mm
-                dims[1] = 2.0 * bbox->GetDY() * 10.0; // Y in mm
-                dims[2] = 2.0 * bbox->GetDZ() * 10.0; // Z in mm
-            } 
-        }
-        // Compare to what is stored in geom_detector.
-        // Use realistic tolerances because regenerated ROOT/GDML may differ at the 0.01-0.1 mm level.
-        const double dx = std::fabs(dims[0] - geom_detector.fScintillatorSizeX);
-        const double dy = std::fabs(dims[1] - geom_detector.fScintillatorSizeY);
-        const double dz = std::fabs(dims[2] - geom_detector.fTotalLength);
-
-        const double warnToleranceMm = 0.05;
-        const double fatalToleranceMm = 1.0;
-
-        if (dx > warnToleranceMm || dy > warnToleranceMm || dz > warnToleranceMm) {
-            std::cerr << "Geometry size check for " << volumeName << ": "
-                      << "TGeoManager(X,Y,Z)=(" << dims[0] << ", " << dims[1] << ", " << dims[2] << ") mm, "
-                      << "geom_detector(X,Y,Z)=(" << geom_detector.fScintillatorSizeX << ", "
-                      << geom_detector.fScintillatorSizeY << ", " << geom_detector.fTotalLength << ") mm, "
-                      << "|delta|=(" << dx << ", " << dy << ", " << dz << ") mm" << std::endl;
+        const std::string prefix = "ContainerLogical";
+        TGeoVolume *targetVolume = nullptr;
+        std::string foundName;
+        TIter next(gGeoManager->GetListOfVolumes());
+        while (TObject *obj = next()) {
+            std::string vname = obj->GetName();
+            // Match "ContainerLogical" but exclude ECal/HCal sub-containers
+            if (vname.rfind(prefix, 0) == 0 &&
+                vname.find("ECal") == std::string::npos &&
+                vname.find("HCal") == std::string::npos) {
+                targetVolume = static_cast<TGeoVolume*>(obj);
+                foundName = vname;
+                break;
+            }
         }
 
-        if (dx > fatalToleranceMm || dy > fatalToleranceMm || dz > fatalToleranceMm) {
-            std::cerr << "FATAL error: Geometry mismatch for " << volumeName
-                      << " exceeds tolerance (" << fatalToleranceMm << " mm)." << std::endl;
-            exit(1);
+        if (targetVolume) {
+            Double_t dims[3] = {0.0, 0.0, 0.0};
+            TGeoShape *shape = targetVolume->GetShape();
+            if (shape) {
+                TGeoBBox *bbox = dynamic_cast<TGeoBBox*>(shape);
+                if (bbox) {
+                    dims[0] = 2.0 * bbox->GetDX() * 10.0;
+                    dims[1] = 2.0 * bbox->GetDY() * 10.0;
+                    dims[2] = 2.0 * bbox->GetDZ() * 10.0;
+                }
+            }
+            const double dx = std::fabs(dims[0] - geom_detector.fScintillatorSizeX);
+            const double dy = std::fabs(dims[1] - geom_detector.fScintillatorSizeY);
+            const double dz = std::fabs(dims[2] - geom_detector.fTotalLength);
+
+            const double warnToleranceMm = 0.05;
+            const double fatalToleranceMm = 1.0;
+
+            if (dx > warnToleranceMm || dy > warnToleranceMm || dz > warnToleranceMm) {
+                std::cerr << "Geometry size check for " << foundName << ": "
+                          << "TGeoManager(X,Y,Z)=(" << dims[0] << ", " << dims[1] << ", " << dims[2] << ") mm, "
+                          << "geom_detector(X,Y,Z)=(" << geom_detector.fScintillatorSizeX << ", "
+                          << geom_detector.fScintillatorSizeY << ", " << geom_detector.fTotalLength << ") mm, "
+                          << "|delta|=(" << dx << ", " << dy << ", " << dz << ") mm" << std::endl;
+            }
+
+            if (dx > fatalToleranceMm || dy > fatalToleranceMm || dz > fatalToleranceMm) {
+                std::cerr << "FATAL error: Geometry mismatch for " << foundName
+                          << " exceeds tolerance (" << fatalToleranceMm << " mm)." << std::endl;
+                exit(1);
+            }
+        } else {
+            std::cerr << "Warning: Volume matching '" << prefix << "' not found in geometry — skipping size check." << std::endl;
         }
-    }
-    else
-    {
-        std::cerr << "Volume '" << volumeName << "' not found." << std::endl;
-        exit(1);
     }
 
     //std::cout << "[TcalEvent] TcalEvent initialized and event loaded." << std::endl;
@@ -596,44 +601,80 @@ ROOT::Math::XYZVector TcalEvent::getChannelXYZRearHCal(int moduleID) const
     return finalGlobalPos;
 }
 
-ROOT::Math::XYZVector TcalEvent::GlobalToMDTLocal(const ROOT::Math::XYZVector& pGlobal_mm) const
+ROOT::Math::XYZVector
+TcalEvent::GlobalToMDTLocal(const ROOT::Math::XYZVector& pGlobal_mm) const
 {
     if (!fHasRearMuSpectGlobalMatrix) {
         std::cerr << "[GlobalToMDTLocal] ERROR: rear muon spectrometer global matrix not cached\n";
         return pGlobal_mm;
     }
-    double global_cm[3] = { pGlobal_mm.X() / 10.0, pGlobal_mm.Y() / 10.0, pGlobal_mm.Z() / 10.0 };
+
+    double global_cm[3] = {
+        pGlobal_mm.X() / 10.0,
+        pGlobal_mm.Y() / 10.0,
+        pGlobal_mm.Z() / 10.0
+    };
+
     double local_cm[3] = {0.0, 0.0, 0.0};
+
     frearMuSpectLocalToGlobal_cm.MasterToLocal(global_cm, local_cm);
-    return ROOT::Math::XYZVector(local_cm[0] * 10.0, local_cm[1] * 10.0,local_cm[2] * 10.0);
+
+    return ROOT::Math::XYZVector(local_cm[0] * 10.0,
+                                 local_cm[1] * 10.0,
+                                 local_cm[2] * 10.0);
 }
 
-ROOT::Math::XYZVector TcalEvent::MDTLocalToGlobal(const ROOT::Math::XYZVector& pLocal_mm) const
+
+ROOT::Math::XYZVector
+TcalEvent::MDTLocalToGlobal(const ROOT::Math::XYZVector& pLocal_mm) const
 {
     if (!fHasRearMuSpectGlobalMatrix) {
         std::cerr << "[MDTLocalToGlobal] ERROR: rear muon spectrometer global matrix not cached\n";
         return pLocal_mm;
     }
-    double local_cm[3] = { pLocal_mm.X() / 10.0, pLocal_mm.Y() / 10.0, pLocal_mm.Z() / 10.0 };
+
+    double local_cm[3] = {
+        pLocal_mm.X() / 10.0,
+        pLocal_mm.Y() / 10.0,
+        pLocal_mm.Z() / 10.0
+    };
+
     double global_cm[3] = {0.0, 0.0, 0.0};
+
     frearMuSpectLocalToGlobal_cm.LocalToMaster(local_cm, global_cm);
 
-    return ROOT::Math::XYZVector(global_cm[0] * 10.0, global_cm[1] * 10.0, global_cm[2] * 10.0);
+    return ROOT::Math::XYZVector(global_cm[0] * 10.0,
+                                 global_cm[1] * 10.0,
+                                 global_cm[2] * 10.0);
 }
 
-ROOT::Math::XYZVector TcalEvent::MDTLocalDirToGlobal(const ROOT::Math::XYZVector& vLocal_mm) const
+
+ROOT::Math::XYZVector
+TcalEvent::MDTLocalDirToGlobal(const ROOT::Math::XYZVector& vLocal_mm) const
 {
-    ROOT::Math::XYZVector oG = MDTLocalToGlobal(ROOT::Math::XYZVector(0.0, 0.0, 0.0));
-    ROOT::Math::XYZVector vG = MDTLocalToGlobal(vLocal_mm);
-    ROOT::Math::XYZVector d(vG.X() - oG.X(), vG.Y() - oG.Y(), vG.Z() - oG.Z());
-    const double mag = std::sqrt(d.X()*d.X() + d.Y()*d.Y() + d.Z()*d.Z());
+    ROOT::Math::XYZVector oG =
+        MDTLocalToGlobal(ROOT::Math::XYZVector(0.0, 0.0, 0.0));
+
+    ROOT::Math::XYZVector vG =
+        MDTLocalToGlobal(vLocal_mm);
+
+    ROOT::Math::XYZVector d(vG.X() - oG.X(),
+                            vG.Y() - oG.Y(),
+                            vG.Z() - oG.Z());
+
+    const double mag =
+        std::sqrt(d.X()*d.X() + d.Y()*d.Y() + d.Z()*d.Z());
+
     if (mag <= 0.0)
         return ROOT::Math::XYZVector(0.0, 0.0, 0.0);
 
-    return ROOT::Math::XYZVector(d.X()/mag, d.Y()/mag, d.Z()/mag);
+    return ROOT::Math::XYZVector(d.X()/mag,
+                                 d.Y()/mag,
+                                 d.Z()/mag);
 }
 
-bool TcalEvent::CacheMDTGlobalMatrix()
+bool
+TcalEvent::CacheMDTGlobalMatrix()
 {
     if (!gGeoManager || !gGeoManager->GetTopVolume()) {
         std::cerr << "[CacheMDTGlobalMatrix] ERROR: geometry not loaded\n";
@@ -643,30 +684,39 @@ bool TcalEvent::CacheMDTGlobalMatrix()
 
     TGeoVolume* top = gGeoManager->GetTopVolume();
     TGeoIterator next(top);
+
     TGeoNode* node = nullptr;
+
     while ((node = next())) {
         std::string nodeName = node->GetName() ? node->GetName() : "";
         std::string volName  = node->GetVolume() && node->GetVolume()->GetName()
                              ? node->GetVolume()->GetName()
                              : "";
+
         const bool isMDTContainer =
             nodeName.find("MDTContainer") != std::string::npos ||
             volName.find("MDTContainer")  != std::string::npos;
 
         if (!isMDTContainer)
             continue;
+
         const TGeoMatrix* fullMat = next.GetCurrentMatrix();
+
         if (!fullMat) {
             std::cerr << "[CacheMDTGlobalMatrix] ERROR: full matrix is null for node="
                       << nodeName << " volume=" << volName << "\n";
             fHasRearMuSpectGlobalMatrix = false;
             return false;
         }
+
         frearMuSpectTGeomNode = node;
+
         // Full MDT-local -> world/master transform, including parent tilt/shift.
         frearMuSpectLocalToGlobal_cm = *fullMat;
         fHasRearMuSpectGlobalMatrix = true;
+
         const double* tr = frearMuSpectLocalToGlobal_cm.GetTranslation();
+
         std::cout << "[CacheMDTGlobalMatrix] cached MDT container\n"
                   << "  node=" << nodeName
                   << " volume=" << volName << "\n"
@@ -680,15 +730,19 @@ bool TcalEvent::CacheMDTGlobalMatrix()
     fHasRearMuSpectGlobalMatrix = false;
     return false;
 }
-void TcalEvent::DumpMDTCandidateNodes() const
+void
+TcalEvent::DumpMDTCandidateNodes() const
 {
     if (!gGeoManager || !gGeoManager->GetTopVolume()) {
         std::cerr << "[DumpMDTCandidateNodes] ERROR: geometry not loaded\n";
         return;
     }
+
     TGeoIterator next(gGeoManager->GetTopVolume());
     TGeoNode* node = nullptr;
+
     std::cout << "\n[DumpMDTCandidateNodes] Candidate MDT/rear-muon nodes:\n";
+
     while ((node = next())) {
         std::string nodeName = node->GetName() ? node->GetName() : "";
         std::string volName  = node->GetVolume() && node->GetVolume()->GetName()
@@ -704,12 +758,15 @@ void TcalEvent::DumpMDTCandidateNodes() const
             volName.find("MuSpect")    != std::string::npos ||
             nodeName.find("Rear")      != std::string::npos ||
             volName.find("Rear")       != std::string::npos;
+
         if (!match)
             continue;
 
         const TGeoMatrix* mat = next.GetCurrentMatrix();
+
         std::cout << "  node=" << nodeName
                   << "  volume=" << volName;
+
         if (mat) {
             const double* tr = mat->GetTranslation();
             std::cout << "  global translation cm=("
@@ -717,11 +774,12 @@ void TcalEvent::DumpMDTCandidateNodes() const
                       << tr[1] << ", "
                       << tr[2] << ")";
         }
+
         std::cout << "\n";
     }
+
     std::cout << "[DumpMDTCandidateNodes] End\n\n";
 }
-
 
 void TcalEvent::fillTree()
 {

--- a/CoreUtils/TcalEvent.hh
+++ b/CoreUtils/TcalEvent.hh
@@ -170,6 +170,7 @@ public:
         Double_t nPEFiber0Direct;
         Double_t nPEFiber1Direct;
         Double_t nPEFiber2Direct;
+        Double_t totalEnergyDeposit;  // Total energy deposited in this voxel (MeV)
     };
     // Umut: to understand whats happening at rear hadron calorimeter
     #if 0

--- a/FASERG4/include/MuonDetMagneticField.hh
+++ b/FASERG4/include/MuonDetMagneticField.hh
@@ -10,8 +10,10 @@ public:
     ~MuonMagneticField() = default;
 
     G4double slitposition = 0.0; // position of the slit along y in mm
+    G4double tiltAngleY = 0.0;   // detector assembly tilt around Y, in radians (same as fTiltAngleY)
 
     void SetSlitPosition(G4double pos) { slitposition = pos; }
+    void SetTiltAngleY(G4double angle) { tiltAngleY = angle; }
     virtual void GetFieldValue(const G4double point[4], G4double* Bfield) const override;
 };
 

--- a/FASERG4/src/DetectorConstruction.cc
+++ b/FASERG4/src/DetectorConstruction.cc
@@ -209,7 +209,7 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 	// DetectorAssemblyPV into the world volume. This simplifies the geometry and ensures
 	// consistent transformations for tilting. The origin of the assembly frame is at the
 	// front middle face of the FaserCal.
-
+	
 	// Sizes of the principal geometrical components (solids)
 	// The values are given via the messenger, same as the units
 
@@ -297,7 +297,7 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 //	CreateFrontTarget(-sizeZ/2.0-20.0*cm, worldLV);
 
 //	zLocation += sizeZ/2.0;
-	zLocation += fTotalLength;  // Move zLocation to the end of FASERCal
+zLocation += fTotalLength;  // Move zLocation to the end of FASERCal
 
 #if magnet
 	// CreateMagnetSystem(zLocation, worldLV);
@@ -307,7 +307,7 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 
 	if (!fonlyFaserCal)
 	{
-		const G4double rearSectionGap = 25.0*cm; // add 25 cm between subdetectors
+		const G4double rearSectionGap = 25.0*cm;
 
 		zLocation += rearSectionGap;
 		fRearCalLocZ = zLocation;
@@ -324,9 +324,9 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 
 		// Keep the same gap between rear HCal and muon spectrometer
 		G4double locMuSpect = locZHcal + fRearHCalLength + rearSectionGap;
-		//fRearMuSpect_LOS_shiftX = fFASERCal_LOS_shiftX + (fRearMuSpectSizeX - fECalSizeX) / 2.0;
-		//fRearMuSpect_LOS_shiftY = fFASERCal_LOS_shiftY + (fRearMuSpectSizeY - fECalSizeY) / 2.0;		//CreateRearMuSpectrometer(locMuSpect, worldLV);
+		// UMUT: LoS shifts removed - applied at assembly level instead
 		//CreateRearMuSpectrometer(locMuSpect, worldLV);
+		// Previous version of the muon spectrometer with scintillator planes
 		//CreateRearMuSpectrometer(locMuSpect, detLV);
 		// New version of the muon spectrometer with MDT (Monitored Drift Tubes)
 		CreateMuSpectWithMDT(locMuSpect, detLV);
@@ -337,8 +337,8 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 	// Put ContainerPlacement front face at world z≈0 by setting assemblyOffsetZ=0
 	// Container is already placed with front face at z=0 in detector frame
 	G4double assemblyOffsetZ = 0;
-	G4double assemblyOffsetX = fFASERCal_LOS_shiftX + fThreeD_CAL_shiftX;
-	G4double assemblyOffsetY = fFASERCal_LOS_shiftY + fThreeD_CAL_shiftY;
+	G4double assemblyOffsetX = fFASERCal_LOS_shiftX;
+	G4double assemblyOffsetY = fFASERCal_LOS_shiftY;
 	new G4PVPlacement(detRot,								// <<< tiltY
 					  G4ThreeVector(assemblyOffsetX, assemblyOffsetY, assemblyOffsetZ), // <<< shift assembly
 					  detLV,
@@ -369,18 +369,15 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
 		// RearHCal container translation relative to detector assembly
 		G4ThreeVector t_hcalCont = hcalContPV->GetTranslation();
 
-		// Apply assembly rotation to get world frame
-		G4ThreeVector inWorld = detRot->inverse() * t_hcalCont;
+		// Apply assembly rotation to get world frame (detRot is nullptr when
+		// tiltY==0, meaning "no rotation" -- identity, not an error).
+		G4ThreeVector inWorld = detRot ? (detRot->inverse() * t_hcalCont) : t_hcalCont;
 
 		G4cout << "=== RearHCal Container center in WORLD ===" << G4endl;
 		G4cout << "  In detector frame (x,y,z) = ("
 			   << t_hcalCont.x() / cm << ", " << t_hcalCont.y() / cm << ", " << t_hcalCont.z() / cm << ") cm" << G4endl;
 		G4cout << "  In world frame    (x,y,z) = ("
 			   << inWorld.x() / cm << ", " << inWorld.y() / cm << ", " << inWorld.z() / cm << ") cm" << G4endl;
-	}
-	else
-	{
-		G4cout << "WARNING: Could not find volumes in store!" << G4endl;
 	}
 
 	G4VPhysicalVolume* containerPV = pvStore->GetVolume("ContainerPlacement");
@@ -477,7 +474,8 @@ void DetectorConstruction::ConstructSDandField()
 		SetSensitiveDetector("rearCalscintillatorLogical", aTrackerSD, false);
 		SetSensitiveDetector("rearHCalscintillatorLogical", aTrackerSD, false);
 		//	SetSensitiveDetector("muCalscintillatorLogical", aTrackerSD, false);
-		//  SetSensitiveDetector("SciFiLayerLV", aTrackerSD, false);
+		//SetSensitiveDetector("SciFiLayerLV", aTrackerSD, false);  // Only for CreateRearMuSpectrometer
+		
 		// Create separate sensitive detector for MDT drift tubes
 		G4String MDTSDname = "/MDTSD";
 		fMDTSD = new MDTSD(MDTSDname);
@@ -644,6 +642,8 @@ void DetectorConstruction::CreateFaserCal(G4double zLocation, G4Material* materi
 	}
 	G4LogicalVolume* trackerSiLogic = new G4LogicalVolume(trackerSiSolid, G4_Si, "trackerSiLogical");
 	G4LogicalVolume* AlPlateLogic = new G4LogicalVolume(AlPlateSolid, G4_Al, "AlPlateLogical");
+
+
     // UMUT: The following layer ordering done
     // Order: AlPlate -> targetW -> Scintillator -> AlPlate -> SiTrackers (disabled)
 	double zShift = -fSandwichLength/2.0 + fAlPlateThickness/2.0;
@@ -656,7 +656,6 @@ void DetectorConstruction::CreateFaserCal(G4double zLocation, G4Material* materi
 	zShift += size1.getZ()/2.0 + fAlPlateThickness/2.0;
 	new G4PVPlacement(0, G4ThreeVector(0,0,zShift), AlPlateLogic, "AlPlate", replicaLogic, false, 1, true);
 
-	//zShift = fSandwichLength/2.0;
 	// UMUT: Silicon trackers disabled
 	#if 0
     new G4PVPlacement(0, G4ThreeVector(0,0,zShift - fSiTrackerGap - fSiTrackerSizeZ/2), 
@@ -700,11 +699,13 @@ void DetectorConstruction::CreateFaserCal(G4double zLocation, G4Material* materi
 static int getchannelIDerrorcount = 0;
 
 G4long DetectorConstruction::getChannelIDfromXYZ(std::string const& VolumeName, int CopyNumber, int MotherCopyNumber, XYZVector const& position) const {
+
 	// UMUT: position is given in the local coordinate system of the volume
 	// Since detectors are now centered in assembly frame, no LoS shift correction needed here
 	G4double epsilon = 1e-6;   // avoid rounding errors at volume boundary
 	G4double dx = position.X()+fScintillatorSizeX/2.0;
 	G4double dy = position.Y()+fScintillatorSizeY/2.0;
+
 	//G4double dz = position.Z()+fTotalLength/2.0-epsilon;
 	G4double zModule = position.Z() + fSandwichLength/2.0;
     G4double zScint  = zModule - fAlPlateThickness - ftargetWSizeZ;
@@ -730,7 +731,7 @@ G4long DetectorConstruction::getChannelIDfromXYZ(std::string const& VolumeName, 
 
 	if(VolumeName == "ScintillatorLogical") {
 
-				G4long ix = floor(((dx-epsilon) / fScintillatorVoxelSize));
+		G4long ix = floor(((dx-epsilon) / fScintillatorVoxelSize));
 		G4long iy = floor(((dy-epsilon) / fScintillatorVoxelSize));
 		//G4long iz = floor((dz-ilayer*fSandwichLength-fAlPlateThickness-ftargetWSizeZ)/ fScintillatorVoxelSize);
 		G4long iz = std::floor((zScint-epsilon) / fScintillatorVoxelSize);
@@ -1104,7 +1105,7 @@ void DetectorConstruction::CreateRearMuSpectrometer(G4double zLocation, G4Logica
 	// Need to shift the muon spectrometer in x and y to account for the fact that it's placed after the rear calorimeter
 	double x =  (fRearMuSpectSizeX - fECalSizeX) / 2.0;
 	double y = (fRearMuSpectSizeY - fECalSizeY) / 2.0;		
-	
+		
 	double z = zLocation + totalLength / 2;
 	G4Box* muonSpectrometerBox = new G4Box("MuonSpectrometer", magnetSizeX / 2, magnetSizeY / 2, totalLength / 2);
 	G4LogicalVolume* muonSpectrometerLV = new G4LogicalVolume(muonSpectrometerBox, air, "MuonSpectrometerLV");
@@ -1160,6 +1161,7 @@ void DetectorConstruction::CreateRearMuSpectrometer(G4double zLocation, G4Logica
 		// Magnetic field on the magnet volume
 		auto field = new MuonMagneticField();
 		field->SetSlitPosition(slitPosition);
+		field->SetTiltAngleY(fTiltAngleY);
 		auto fieldManager = new G4FieldManager(field);
 		fieldManager->CreateChordFinder(field);
 		magnetLV->SetFieldManager(fieldManager, true);
@@ -1426,6 +1428,7 @@ void DetectorConstruction::CreateMuSpectWithMDT(G4double zLocation, G4LogicalVol
 		// Magnetic field on the magnet volume
 		auto field = new MuonMagneticField();
 		field->SetSlitPosition(250.*mm);
+		field->SetTiltAngleY(fTiltAngleY);
 		auto fieldManager = new G4FieldManager(field);
 		fieldManager->CreateChordFinder(field);
 		magnetLV->SetFieldManager(fieldManager, true);

--- a/FASERG4/src/MDTSD.cc
+++ b/FASERG4/src/MDTSD.cc
@@ -85,18 +85,32 @@ G4bool MDTSD::ProcessHits(G4Step* step, G4TouchableHistory*)
   G4ThreeVector trueMom = pre->GetMomentum();
 
   // ------------------------------------------------------------
-  // MDT wire is along global X (assumption: tubes oriented along X).
-  // If the geometry changes tube orientation this must be updated.
-  // Therefore the drift radius is calculated in the Y-Z plane.
-  //
-  // We compute the minimum distance between the Geant4 step segment
-  // and the wire center in the Y-Z plane.
+  // True wire axis in global coordinates, from the actual accumulated
+  // placement transform (tube's own rotation + all parent rotations,
+  // including any detector-assembly tilt). The G4Tubs solid's cylinder
+  // axis is along its own local Z; this correctly follows wherever that
+  // axis actually points after tilting, instead of assuming global X.
   // ------------------------------------------------------------
-  G4double y0 = p0.y() - tubeCenter.y();
-  G4double z0 = p0.z() - tubeCenter.z();
+  G4ThreeVector wireAxis =
+    touchable->GetHistory()->GetTopTransform().Inverse().TransformAxis(G4ThreeVector(0., 0., 1.));
+  wireAxis = wireAxis.unit();
 
-  G4double y1 = p1.y() - tubeCenter.y();
-  G4double z1 = p1.z() - tubeCenter.z();
+  // Transverse basis perpendicular to the wire axis. Global Y is exactly
+  // perpendicular to any wire axis produced by a rotation about Y (a tilt
+  // about Y never changes the Y-component), so it stays valid and matches
+  // the "measured" (drift) direction convention used in reconstruction.
+  const G4ThreeVector uAxis(0., 1., 0.);
+  G4ThreeVector vAxis = wireAxis.cross(uAxis).unit();
+
+  // We compute the minimum distance between the Geant4 step segment
+  // and the wire center in the plane transverse to the true wire axis.
+  G4ThreeVector d0 = p0 - tubeCenter;
+  G4ThreeVector d1 = p1 - tubeCenter;
+
+  G4double y0 = d0 * uAxis;
+  G4double z0 = d0 * vAxis;
+  G4double y1 = d1 * uAxis;
+  G4double z1 = d1 * vAxis;
 
   G4double dy = y1 - y0;
   G4double dz = z1 - z0;
@@ -112,7 +126,7 @@ G4bool MDTSD::ProcessHits(G4Step* step, G4TouchableHistory*)
     if (t > 1.0) t = 1.0;
   }
 
-  // Closest point on the step segment to the wire center in Y-Z plane
+  // Closest point on the step segment to the wire center in the transverse plane.
   // This is the point of closest approach to the wire
   // close to what we see in the real detector, where the drift radius is measured.
   G4double yClosest = y0 + t * dy;
@@ -123,14 +137,12 @@ G4bool MDTSD::ProcessHits(G4Step* step, G4TouchableHistory*)
 
   G4double driftAngle = std::atan2(zClosest, yClosest);
 
-  G4ThreeVector closestPos(
-    p0.x() + t * (p1.x() - p0.x()),
-    tubeCenter.y() + yClosest,
-    tubeCenter.z() + zClosest
-  );
+  // Point on the step segment at parameter t: exact regardless of basis,
+  // since t was chosen to minimize transverse distance to the wire line.
+  G4ThreeVector closestPos = p0 + t * (p1 - p0);
 
-  // hitX: position along the tube in local (tube-centered) X coordinates
-  G4double hitX = closestPos.x() - tubeCenter.x();
+  // hitX: true position along the (possibly tilted) wire axis, not just the X component.
+  G4double hitX = (closestPos - tubeCenter) * wireAxis;
 
   // Simple reference drift time
   const G4double driftVelocity = 0.025 * mm / ns;

--- a/FASERG4/src/MuonDetMagneticField.cc
+++ b/FASERG4/src/MuonDetMagneticField.cc
@@ -48,16 +48,25 @@ void MuonMagneticField::GetFieldValue(const G4double point[4], G4double* Bfield)
 #endif
     Bfield[0] = Bfield[1] = Bfield[2] = 0.0;
 
-    // Assume ±1.5 Tesla in steel, depending on y (top/bottom vs center)
+    // Assume ±1.5 Tesla in steel, depending on y (top/bottom vs center).
+    // Rotation around Y leaves y unchanged, so the global y coordinate
+    // already equals the tilted assembly's local y — no correction needed here.
+    G4double Blocal = 0.0;
     if (std::abs(y) >= slitposition * mm && std::abs(y) <= 2 * slitposition * mm) {
       // Top or Bottom: +1.5 T
-      Bfield[0] = +1.5 * tesla;
+      Blocal = +1.5 * tesla;
     } else if (std::abs(y) < slitposition * mm) {
       // Middle: –1.5 T
-      Bfield[0] = -1.5 * tesla;
+      Blocal = -1.5 * tesla;
     }
 
-    
+    // The field points along the Fe slab's local +x axis, which is tilted
+    // by tiltAngleY (rad) around Y with respect to the global frame (same
+    // rotation as new G4RotationMatrix()->rotateY(fTiltAngleY) used to place
+    // the detector assembly). Rotate the local field vector into global
+    // coordinates so it stays aligned with the iron even when tilted.
+    Bfield[0] = Blocal * std::cos(tiltAngleY);
+    Bfield[2] = Blocal * std::sin(tiltAngleY);
 }
 /*
 // previously used code


### PR DESCRIPTION
MDT issue:
it was found that the magnetic field was not tilted.. it is corrected and accordingly some part also modified in MDTSD.cc and some other files. GenFit Kalman fitter for muon track improved and the results much betetr wrt previous. Still some problem exist in charge determination.

Detector response for prototype:
TPORecoEvent.cc/hh modified for detector response (for a long time i forget to submit and merge the changes): adding smearing, tuning xtalk, etc. In the next iteration i will merge FASERCalProtoG4..
  